### PR TITLE
Added Grok Build install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Then start a new session and ask:
 
 The agent loads the `godot-project-setup` skill and provides a complete directory structure, autoload setup, and .gitignore — not generic advice.
 
+### Grok Build
+```bash
+grok plugin install jame581/GodotPrompter --trust
+grok plugin enable godot-prompter
+```
+
+Pin to a release:
+```bash
+grok plugin install jame581/GodotPrompter@v1.9.0 --trust
+grok plugin enable godot-prompter
+```
+
 ### Gemini CLI
 
 ```bash


### PR DESCRIPTION
## Summary

Added grok build install instructions to quick start. Tested on my own system.

## Related issues

#4 [Feature] Grok Build Install Instructions

## Type of change

- [x] Documentation
- [ ] New skill
- [ ] Skill update
- [ ] Agent update
- [ ] Tooling / packaging
- [ ] Tests
- [ ] Other

## What changed

- [x] Added or updated the relevant documentation
- [x] Kept changes focused on the intended scope
- [x] Included any needed tests or validation updates

## Skill-specific checklist

If this PR changes a skill, confirm the applicable items below.

- [ ] `SKILL.md` keeps valid YAML frontmatter
- [ ] The skill folder uses kebab-case naming
- [ ] The description starts with `Use when`
- [ ] GDScript examples use Godot 4.x APIs
- [ ] C# examples use Godot 4.x APIs
- [ ] GDScript and C# coverage stay aligned where applicable
- [ ] Related skill references are valid

## Validation

I installed the skill on grok build and used the steps to write the changes in markdown.

## Notes for reviewers

Simple README.md change.