### PR TITLE
v1.10.0 — Ecosystem & Abilities (48 → 51 skills)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "godot-prompter",
       "description": "Agentic skills framework for Godot 4.x game development — 48 domain-specific skills for GDScript and C#",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "source": "./",
       "author": {
         "name": "Jan Mesarc"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "godot-prompter",
-      "description": "Agentic skills framework for Godot 4.x game development — 48 domain-specific skills for GDScript and C#",
+      "description": "Agentic skills framework for Godot 4.x game development — 51 domain-specific skills for GDScript and C#",
       "version": "1.10.0",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-prompter",
-  "description": "Agentic skills framework for Godot 4.x game development — 48 domain-specific skills for GDScript and C#",
+  "description": "Agentic skills framework for Godot 4.x game development — 51 domain-specific skills for GDScript and C#",
   "version": "1.10.0",
   "author": {
     "name": "Jan Mesarc"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "godot-prompter",
   "description": "Agentic skills framework for Godot 4.x game development — 48 domain-specific skills for GDScript and C#",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "Jan Mesarc"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "godot-prompter",
   "displayName": "GodotPrompter",
   "description": "Agentic skills framework for Godot 4.x — 48 domain-specific skills for GDScript and C#",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "Jan Mesarc"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "godot-prompter",
   "displayName": "GodotPrompter",
-  "description": "Agentic skills framework for Godot 4.x — 48 domain-specific skills for GDScript and C#",
+  "description": "Agentic skills framework for Godot 4.x — 51 domain-specific skills for GDScript and C#",
   "version": "1.10.0",
   "author": {
     "name": "Jan Mesarc"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to GodotPrompter will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.10.0] - 2026-06-17
+
+### Added
+
+- **3 new skills** (48 → 51):
+  - `ability-system` — core gameplay systems: ability definition/cost/cooldown/cast lifecycle, buff/debuff stacks, stat-modifier pipeline, gameplay tags and conditions, HUD binding patterns. Pattern X with 3 references (`stat-modifiers`, `tags-and-conditions`, `ui-binding`); full C# parity throughout.
+  - `limboai` *(Third-Party Addons)* — LimboAI v1.7.1 behavior tree + hierarchical state machine: `BTTask` authoring, BT runner setup, HSM state definitions and transitions, C++ GDExtension install, C# via module build. Reference: `hsm.md`.
+  - `beehave` *(Third-Party Addons)* — Beehave v2.9.2 pure-GDScript behavior tree: `BeehaveTree` setup, action/condition node authoring, composite nodes, selector/sequence semantics, custom node extension. Reference: `custom-nodes.md`. GDScript-only by design (Beehave ships no C# API).
+- New **Third-Party Addons** README category — first community-addon coverage in the repository; addon skills pin the addon version and install source.
+- **Antigravity** added as a 6th supported platform: `references/antigravity-tools.md` tool mapping added to `using-godot-prompter`; bootstrap wiring in README and CLAUDE.md. Format verified; runtime install pending (no live Antigravity binary on the release machine).
+
+### Changed
+
+- Cross-ref wiring: `ability-system` linked from `state-machine`, `hud-system`, `inventory-system`, `component-system`, `event-bus`; `limboai` and `beehave` linked from `ai-navigation`, `state-machine`, `godot-brainstorming`; `ability-system` linked from `limboai`.
+- Light agent edits: `godot-game-architect` and `godot-game-dev` routing notes extended to cover the new ability-system and third-party addon skills.
+
+> **Release notes:** 3 new skills (48 → 51); first Third-Party Addons category in the repo. All addon content grounded against official LimboAI and Beehave repositories (cloned, version-pinned); see `docs/superpowers/notes/2026-06-17-limboai-research.md` and `docs/superpowers/notes/2026-06-17-beehave-research.md`. Validator baseline at release: 0 errors, 13 warnings (10 pre-existing `csharp-parity-accepted` + 3 new `csharp-parity-accepted` from `beehave` being GDScript-only, now allowlisted; 0 token-budget). Every SKILL.md ≤ 16 KB. 51 skills. Repo-wide minimum stays at Godot 4.3+.
+
 ## [1.9.0] - 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Cross-ref wiring: `ability-system` linked from `state-machine`, `hud-system`, `inventory-system`, `component-system`, `event-bus`; `limboai` and `beehave` linked from `ai-navigation`, `state-machine`, `godot-brainstorming`; `ability-system` linked from `limboai`.
+- Cross-ref wiring: `ability-system` back-linked from `component-system`, `event-bus`, `hud-system`, `resource-pattern`, `state-machine`; `limboai` and `beehave` linked from `ai-navigation` and `state-machine` (and cross-linked to each other); `ability-system` linked from `limboai`.
 - Light agent edits: `godot-game-architect` and `godot-game-dev` routing notes extended to cover the new ability-system and third-party addon skills.
 
 > **Release notes:** 3 new skills (48 → 51); first Third-Party Addons category in the repo. All addon content grounded against official LimboAI and Beehave repositories (cloned, version-pinned); see `docs/superpowers/notes/2026-06-17-limboai-research.md` and `docs/superpowers/notes/2026-06-17-beehave-research.md`. Validator baseline at release: 0 errors, 13 warnings (10 pre-existing `csharp-parity-accepted` + 3 new `csharp-parity-accepted` from `beehave` being GDScript-only, now allowlisted; 0 token-budget). Every SKILL.md ≤ 16 KB. 51 skills. Repo-wide minimum stays at Godot 4.3+.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ This is a **documentation/skills repository**. There is no application build/lin
 - Codex
 - Cursor
 - OpenCode
+- Antigravity
 
 ## Conventions
 
@@ -36,7 +37,7 @@ This is a **documentation/skills repository**. There is no application build/lin
 ## Repository Structure
 
 ```
-skills/                     # 48 domain-specific skill folders
+skills/                     # 51 domain-specific skill folders
   <skill-name>/
     SKILL.md                # Main skill document (YAML frontmatter required) — keep ≤ 16 KB (v1.7.0 token-budget rule)
     references/             # Optional load-on-demand deep dives (Pattern X)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Godot 4.x](https://img.shields.io/badge/Godot-4.3+-blue.svg)](https://godotengine.org)
-[![Skills: 48](https://img.shields.io/badge/Skills-48-green.svg)](#available-skills)
+[![Skills: 51](https://img.shields.io/badge/Skills-51-green.svg)](#available-skills)
 
 Agentic skills framework for Godot 4.x game development. Gives AI coding agents domain-specific expertise for GDScript and C# projects.
 
@@ -12,7 +12,7 @@ Inspired by and built on top of the [Superpowers](https://github.com/obra/superp
 
 GodotPrompter is a plugin that provides **skills** — structured domain knowledge that AI agents load on demand. When you ask your agent to "add a state machine" or "set up multiplayer", it loads the relevant GodotPrompter skill and follows Godot-specific best practices instead of relying on generic knowledge.
 
-**48 skills** covering project setup, architecture, gameplay systems, input handling, physics, 2D/3D systems, animation, shaders, audio, UI, multiplayer, localization, procedural generation, XR/VR, native extensions, multithreading, mobile shipping, optimization, and GDScript / C# patterns. All targeting Godot 4.3+ with both GDScript and C# examples — newer features from Godot 4.5 and 4.6 (variadic functions, abstract classes, stencil buffers, SoftBody3D forces, FoldableContainer, OpenXR Spatial Entities, and more) are included as annotated additive sections.
+**51 skills** covering project setup, architecture, gameplay systems, input handling, physics, 2D/3D systems, animation, shaders, audio, UI, multiplayer, localization, procedural generation, XR/VR, native extensions, multithreading, mobile shipping, optimization, GDScript / C# patterns, and third-party addons (LimboAI, Beehave). All targeting Godot 4.3+ with both GDScript and C# examples — newer features from Godot 4.5 and 4.6 (variadic functions, abstract classes, stencil buffers, SoftBody3D forces, FoldableContainer, OpenXR Spatial Entities, and more) are included as annotated additive sections.
 
 **v1.7.0 introduces a 16 KB token budget** for `SKILL.md` files (validator-enforced) and the new **`gdscript-advanced`** skill for production-grade GDScript depth (performance idioms, metaprogramming, `@tool` lifecycle, profiler-driven idioms).
 
@@ -160,6 +160,7 @@ GodotPrompter includes 9 specialized agents:
 | Cursor | Supported | `/add-plugin godot-prompter` or clone with `.cursor-plugin/` |
 | Codex | Supported | Clone + symlink (see `.codex/INSTALL.md`) |
 | OpenCode | Supported | Add to `opencode.json` (see `.opencode/INSTALL.md`) |
+| Antigravity | Supported | Install via the Antigravity plugin marketplace |
 
 > **Legacy marketplace:** The [`godot-prompter-marketplace`](https://github.com/jame581/godot-prompter-marketplace) repo remains online so existing installs keep receiving updates, but new users should install from [`skillsmith`](https://github.com/jame581/skillsmith).
 
@@ -196,7 +197,7 @@ GodotPrompter includes 9 specialized agents:
 | `3d-essentials` | Materials, lighting, shadows, environment, GI, fog, LOD, occlusion, decals |
 | `xr-development` | OpenXR, XROrigin3D, hand tracking, controllers, passthrough, Meta Quest |
 
-### Gameplay Systems (12 skills)
+### Gameplay Systems (13 skills)
 
 | Skill | Description |
 |-------|-------------|
@@ -209,6 +210,7 @@ GodotPrompter includes 9 specialized agents:
 | `dialogue-system` | Branching dialogue trees, conditions, UI presentation |
 | `save-load` | ConfigFile, JSON, Resource serialization, version migration |
 | `ai-navigation` | NavigationAgent2D/3D, steering behaviors, patrol patterns, async baking |
+| `ability-system` | Resource-based abilities, cost/cooldown/cast, buffs/debuffs, stat modifiers, gameplay tags, HUD binding |
 | `camera-system` | Smooth follow, screen shake, camera zones, transitions |
 | `localization` | TranslationServer, CSV/PO files, locale switching, RTL support, pluralization |
 | `procedural-generation` | Noise, BSP dungeons, cellular automata, WFC, seeded randomness |
@@ -268,6 +270,15 @@ GodotPrompter includes 9 specialized agents:
 |-------|-------------|
 | `math-essentials` | Vectors, transforms, interpolation, curves, paths, RNG, game math recipes |
 
+### Third-Party Addons (2 skills)
+
+These skills cover community addons with pinned versions — LimboAI v1.7.1 and Beehave v2.9.2. They require the corresponding addon to be installed in your project.
+
+| Skill | Description |
+|-------|-------------|
+| `limboai` | LimboAI addon — behavior trees + hierarchical state machines, visual editor, blackboard, BTTask subclassing (Godot 4.6+, C++ GDExtension) |
+| `beehave` | Beehave addon — pure-GDScript behavior trees, composites/decorators/leaves, blackboard, visual runtime debugger (GDScript-only) |
+
 ## Validation
 
 Quality is enforced by an automated validator that runs on every release tag. Human-readable run:
@@ -300,7 +311,7 @@ Produces a per-skill / per-agent table (bytes, KB, estimated tokens, Claude / GP
 
 CI gate: `.github/workflows/release.yml` runs both `node scripts/validate-skills.mjs` and a tag-vs-manifest version-consistency check on every `v*.*.*` push. The release is blocked if the validator returns errors or any of `package.json` / `.claude-plugin/plugin.json` / `.claude-plugin/marketplace.json` drifts from the tag.
 
-**Current baseline (v1.9.0):** 0 errors, 10 warnings (all `csharp-parity-accepted` GDScript-only; 0 token-budget). Every `SKILL.md` is at or below the 16 KB budget.
+**Current baseline (v1.10.0):** 0 errors, 13 warnings (all `csharp-parity-accepted` GDScript-only; 0 token-budget). Every `SKILL.md` is at or below the 16 KB budget.
 
 A manual agent-integration test plan covering full workflows (skill discovery, cross-reference navigation, end-to-end feature implementation) lives in [`tests/agent-integration/TEST_PLAN.md`](tests/agent-integration/TEST_PLAN.md) for spot-checks against new agent versions or platforms.
 

--- a/agents/godot-game-architect.md
+++ b/agents/godot-game-architect.md
@@ -20,7 +20,8 @@ You have access to GodotPrompter skills — read them for authoritative Godot pa
 
 - **Architecture:** Read `skills/scene-organization/SKILL.md`, `skills/state-machine/SKILL.md`, `skills/event-bus/SKILL.md`, `skills/component-system/SKILL.md`, `skills/resource-pattern/SKILL.md`, `skills/dependency-injection/SKILL.md`
 - **Design:** Read `skills/godot-brainstorming/SKILL.md` for structured design process
-- **Gameplay:** Read `skills/player-controller/SKILL.md`, `skills/input-handling/SKILL.md`, `skills/ai-navigation/SKILL.md`, `skills/inventory-system/SKILL.md`, `skills/dialogue-system/SKILL.md`, `skills/camera-system/SKILL.md`, `skills/save-load/SKILL.md`
+- **Gameplay:** Read `skills/player-controller/SKILL.md`, `skills/input-handling/SKILL.md`, `skills/ai-navigation/SKILL.md`, `skills/ability-system/SKILL.md`, `skills/inventory-system/SKILL.md`, `skills/dialogue-system/SKILL.md`, `skills/camera-system/SKILL.md`, `skills/save-load/SKILL.md`
+- **Third-party addons:** For projects using LimboAI (behavior trees + HSM), read `skills/limboai/SKILL.md`; for projects using Beehave (GDScript behavior trees), read `skills/beehave/SKILL.md`.
 - **Animation & VFX:** Read `skills/animation-system/SKILL.md`, `skills/tween-animation/SKILL.md`, `skills/particles-vfx/SKILL.md`
 - **Rendering:** Read `skills/shader-basics/SKILL.md`, `skills/2d-essentials/SKILL.md`, `skills/3d-essentials/SKILL.md`
 - **Audio:** Read `skills/audio-system/SKILL.md`

--- a/agents/godot-game-dev.md
+++ b/agents/godot-game-dev.md
@@ -22,7 +22,8 @@ You have access to GodotPrompter skills — read them before writing code:
 
 - **Core:** `skills/godot-project-setup/SKILL.md`, `skills/godot-debugging/SKILL.md`, `skills/godot-testing/SKILL.md`
 - **Architecture:** `skills/scene-organization/SKILL.md`, `skills/state-machine/SKILL.md`, `skills/event-bus/SKILL.md`, `skills/component-system/SKILL.md`, `skills/resource-pattern/SKILL.md`
-- **Gameplay:** `skills/player-controller/SKILL.md`, `skills/input-handling/SKILL.md`, `skills/ai-navigation/SKILL.md`, `skills/inventory-system/SKILL.md`, `skills/dialogue-system/SKILL.md`, `skills/camera-system/SKILL.md`, `skills/save-load/SKILL.md`
+- **Gameplay:** `skills/player-controller/SKILL.md`, `skills/input-handling/SKILL.md`, `skills/ai-navigation/SKILL.md`, `skills/ability-system/SKILL.md`, `skills/inventory-system/SKILL.md`, `skills/dialogue-system/SKILL.md`, `skills/camera-system/SKILL.md`, `skills/save-load/SKILL.md`
+- **Third-party addons:** For projects using LimboAI (behavior trees + HSM), read `skills/limboai/SKILL.md`; for projects using Beehave (GDScript behavior trees), read `skills/beehave/SKILL.md`.
 - **Animation & VFX:** `skills/animation-system/SKILL.md`, `skills/tween-animation/SKILL.md`, `skills/particles-vfx/SKILL.md`
 - **Audio:** `skills/audio-system/SKILL.md`
 - **UI:** `skills/godot-ui/SKILL.md`, `skills/responsive-ui/SKILL.md`, `skills/hud-system/SKILL.md`

--- a/docs/superpowers/notes/2026-06-17-antigravity-research.md
+++ b/docs/superpowers/notes/2026-06-17-antigravity-research.md
@@ -1,0 +1,256 @@
+# Antigravity — Platform Research Digest (for v1.10.0 platform support)
+
+> Gathered 2026-06-17 from official Google Codelabs, Google Cloud Community (Medium), agentpedia.codes,
+> and Dazbo/Deven Goratela's MCP+Skills guide, to pin the skill-loading facts needed before Task 13
+> (tool-mapping file) can be written.
+>
+> **Official docs caveat:** `https://antigravity.google/docs/skills` and
+> `https://antigravity.google/docs/sdk-overview` both return empty pages (client-side rendering).
+> All findings are triangulated from the sources cited inline. Confidence levels are stated explicitly.
+>
+> **Local install check (2026-06-17):** No Antigravity install found on this Windows machine.
+> `~/.gemini/` does not exist; no `agy` binary present.
+
+## 1. What is Antigravity?
+
+Google Antigravity (announced at Google I/O 2026) is an agent-first coding platform that ships as four
+components:
+
+- **Antigravity 2.0** — the flagship desktop app (agent-first, VS Code-based)
+- **Antigravity IDE** — VS Code fork with deep agent integration
+- **Antigravity CLI** (`agy`) — a Go-based terminal-first agent (successor to Gemini CLI)
+- **Antigravity SDK** — Python library for programmatic agent construction
+
+All four share the same skill format (`SKILL.md`) and global config directory. Sources:
+[TechCrunch I/O 2026 announcement](https://techcrunch.com/2026/05/19/google-launches-antigravity-2-0-with-an-updated-desktop-app-and-cli-tool-at-io-2026/),
+[MarkTechPost](https://www.marktechpost.com/2026/05/19/google-launches-antigravity-2-0-at-i-o-2026-a-standalone-agent-first-platform-with-cli-sdk-managed-execution-and-enterprise-support/).
+
+## 2. Workspace (project-scoped) skills directory — RESOLVED
+
+**Recommended path: `.agents/skills/<skill-name>/SKILL.md`**
+
+This is the current standard as of 2026. It is confirmed by three independent sources:
+
+| Source | Claimed path | Authority |
+|--------|-------------|-----------|
+| [Google Codelabs "Getting Started"](https://codelabs.developers.google.com/getting-started-google-antigravity) | `.agents/skills/` | Official |
+| [Google Codelabs "Autonomous Dev Pipelines"](https://codelabs.developers.google.com/autonomous-ai-developer-pipelines-antigravity) | `.agents/skills/` | Official |
+| [agentpedia.codes CLI Deep Dive](https://agentpedia.codes/blog/antigravity-cli-deep-dive) | `.agents/skills/` | Community |
+| [agentpedia.codes Skills Setup Guide](https://agentpedia.codes/blog/antigravity-skills-setup-guide) | `.agent/skills/` | Community |
+| [agensi.io Skills Guide](https://www.agensi.io/learn/antigravity-ide-skills-guide) | `.antigravity/skills/` | Community |
+| [George Mao, Medium](https://medium.com/google-cloud/tutorial-getting-started-with-antigravity-skills-864041811e0d) | `.agent/skills/` (CLI) / `.agents/skills/` (IDE) | Google Cloud Community |
+
+**Resolution:**
+
+- `.agents/skills/` (plural) is the **current standard** for all Antigravity products (IDE, 2.0, CLI).
+  Confirmed by two official Google Codelabs.
+- `.agent/skills/` (singular) is an **older convention** from the Gemini CLI era / early Antigravity CLI,
+  maintained for backward compatibility. George Mao's article (Google Cloud Community, June 2026) treats
+  `.agent/skills/` as CLI-specific and `.agents/skills/` as IDE-standard. agentpedia.codes Skills Setup
+  Guide uses `.agent/skills/` but its CLI Deep Dive article (a later piece) uses `.agents/skills/`.
+- `.antigravity/skills/` is mentioned only by agensi.io and is not corroborated by any official source or
+  other community guide. **Treat as incorrect or product-specific variant — not recommended.**
+
+**Confidence: HIGH** that `.agents/skills/` is the correct current workspace path for Antigravity 2.0 and
+IDE. **MEDIUM** that `.agent/skills/` still works for the CLI (backward compat). `.antigravity/skills/`
+should not be used.
+
+## 3. Global skills directory — PARTIALLY RESOLVED
+
+Three paths appear in the literature. Dazbo's guide (the most technically detailed community source)
+explicitly tested all of them:
+
+| Source | Claimed global path | Status |
+|--------|-------------------|--------|
+| Brief / initial search summary | `~/.gemini/antigravity/skills/` | **Incorrect per Dazbo** |
+| [Dazbo / Deven Goratela](https://devengoratela.com/2026/05/configuring-mcp-servers-and-skills-for-antigravity-cli-and-ide/) | `~/.gemini/skills/` | Verified working (shared across all tools) |
+| [Dazbo / Deven Goratela](https://devengoratela.com/2026/05/configuring-mcp-servers-and-skills-for-antigravity-cli-and-ide/) | `~/.gemini/antigravity-cli/skills/` | Working for CLI only |
+| [Google Codelabs "Getting Started"](https://codelabs.developers.google.com/getting-started-google-antigravity) | `~/.gemini/config/skills/` | Official codelab |
+| [George Mao, Medium](https://medium.com/google-cloud/deep-dive-antigravity-agent-skills-b303bf05085b) | `~/.gemini/skills/` | Google Cloud Community |
+
+**Resolution:**
+
+- `~/.gemini/skills/` is the **recommended global path** for skills shared across all Antigravity tools.
+  Confirmed by both George Mao (Google Cloud Community) and Dazbo's live test.
+- `~/.gemini/config/skills/` is cited in an official codelab — functionally equivalent to
+  `~/.gemini/skills/` or a valid alternative config sub-path. Treat as a valid alias until confirmed
+  otherwise.
+- `~/.gemini/antigravity-cli/skills/` is CLI-specific only.
+- `~/.gemini/antigravity/skills/` is **confirmed incorrect** by Dazbo's live testing — skills placed
+  there are not picked up.
+
+**Confidence: HIGH** that `~/.gemini/skills/` is the right shared global path.
+**Confidence: MEDIUM** on `~/.gemini/config/skills/` being an equivalent alias.
+
+## 4. SKILL.md frontmatter fields
+
+Three fields are documented across sources:
+
+```yaml
+---
+name: my-skill-name        # required — skill identifier; defaults to directory name if omitted
+description: Use when ...  # required — semantic trigger for skill activation (most important field)
+tools: mcp_server_name_*   # optional — filters which MCP servers the skill can access
+---
+```
+
+Details:
+
+- **`name`**: Required identifier. Lowercase with hyphens. Defaults to the directory name if omitted
+  (per official Codelabs). Sources:
+  [Google Codelabs](https://codelabs.developers.google.com/getting-started-google-antigravity),
+  [George Mao (Medium)](https://medium.com/google-cloud/tutorial-getting-started-with-antigravity-skills-864041811e0d).
+- **`description`**: The most important field; functions as the semantic trigger for skill activation.
+  Mandatory. Sources: same as above.
+- **`tools`**: Optional. Specifies which MCP server(s) the skill can access, using wildcard syntax (e.g.,
+  `mcp_google-developer-knowledge_*`). This filters available MCP tools when the skill runs, reducing
+  context noise. Source: [George Mao (Medium)](https://medium.com/google-cloud/deep-dive-antigravity-agent-skills-b303bf05085b).
+- One source ([mcpdirectory.app](https://mcpdirectory.app/blog/how-to-use-antigravity-skills-2026)) also
+  lists `version` — but this is not corroborated by any official source. Treat as unofficial/optional.
+
+**GodotPrompter implication:** GodotPrompter's existing `name:` and `description:` frontmatter is already
+compatible. No `tools:` override is needed for the base skill install (users can add it themselves if they
+want to scope skills to specific MCP servers). No format changes required for the existing skill files.
+
+## 5. `references/` subdirectory handling
+
+Behavior is **not automatically indexed** — Antigravity does not scan `references/` at load time and
+inject the contents into context. The body of `SKILL.md` must explicitly instruct the agent to read a
+specific file from the `references/` folder when it is needed.
+
+This is consistent with how GodotPrompter already uses Pattern X: the skill body contains "if you need
+detail on X, read `references/X.md`." That instruction works the same way in Antigravity.
+
+Sources:
+[Google Codelabs "Getting Started"](https://codelabs.developers.google.com/getting-started-google-antigravity)
+(confirms `references/` holds on-demand content, not auto-loaded);
+[agentpedia.codes Skills Setup Guide](https://agentpedia.codes/blog/antigravity-skills-setup-guide)
+("large schemas, templates, and documentation should go in references/ — not in the SKILL.md body").
+
+**Confidence: HIGH.** Both official codelab and community sources agree that `references/` is read on
+explicit instruction, not auto-indexed. This is the same behavior as Claude Code.
+
+## 6. AGENTS.md / rules file
+
+Mixed picture across sources:
+
+- The `AGENTS.md` at the GodotPrompter repo root is a re-export that delegates to the
+  `using-godot-prompter` skill. Antigravity does not natively read `AGENTS.md` in the same way Codex
+  does (it is not a recognised Antigravity config file).
+- However, the Autonomous Dev Pipelines codelab uses `.agents/agents.md` (lowercase `a`, inside the
+  `.agents/` folder) as an agent-persona definition file distinct from skills. This is different from
+  the root `AGENTS.md` Codex reads.
+- Dazbo's guide references `~/.gemini/GEMINI.md` as a config file (user preferences / system instructions),
+  analogous to Claude Code's `CLAUDE.md`.
+
+**Conclusion:** GodotPrompter's root `AGENTS.md` will NOT be auto-read by Antigravity as project
+instructions. For Antigravity users who want project-level system instructions, the equivalent would be
+placing instructions in a `.gemini/GEMINI.md` file at the project root. This is a gap to note in the
+`using-godot-prompter` skill when Antigravity support is added (Task 13).
+
+Sources:
+[Codelabs Autonomous Pipelines](https://codelabs.developers.google.com/autonomous-ai-developer-pipelines-antigravity),
+[Dazbo / Deven Goratela](https://devengoratela.com/2026/05/configuring-mcp-servers-and-skills-for-antigravity-cli-and-ide/).
+
+## 7. Antigravity built-in tool names
+
+The Antigravity CLI hands-on codelab and related sources reveal these tool function names:
+
+| Claude Code tool (canonical) | Antigravity CLI equivalent | Source |
+|-----------------------------|---------------------------|--------|
+| `Read` (file reading) | `Read()` | [Codelabs Hands-On](https://codelabs.developers.google.com/antigravity-cli-hands-on) |
+| `Write` (file creation) | `Create()` | [Codelabs Hands-On](https://codelabs.developers.google.com/antigravity-cli-hands-on) |
+| `Edit` (file editing) | `Edit()` / `Replace()` (unconfirmed exact name) | Inferred from "multi-file editing" capability docs |
+| `Bash` (run commands) | `Bash()` | [WebSearch result](https://beginnersinai.org/google-antigravity/) |
+| `Glob` (search files by name) | `ListDir()` | [Codelabs Hands-On](https://codelabs.developers.google.com/antigravity-cli-hands-on) |
+| `Grep` (search file content) | Likely `grep`-like via `Bash()` | No explicit tool found |
+| `WebSearch` (web search) | `WebSearch()` | [Codelabs Hands-On](https://codelabs.developers.google.com/antigravity-cli-hands-on) |
+| `WebFetch` (fetch a URL) | `ReadURL()` | [Codelabs Hands-On](https://codelabs.developers.google.com/antigravity-cli-hands-on) |
+| `Task` (dispatch subagent) | `Subagent()` / delegate via natural language | Inferred from subagent capability docs |
+| `Skill` (invoke a skill) | No equivalent tool call — skills activate via description matching | Multiple sources |
+
+**Confidence notes:**
+- `Read()`, `Create()`, `ListDir()`, `ReadURL()`, `WebSearch()` — **HIGH** (verbatim from official codelab).
+- `Bash()` — **HIGH** (multiple sources confirm shell execution tool).
+- `Edit()` / `Replace()` — **LOW** (name not confirmed; multi-file editing is documented as a capability
+  but the exact tool function name is not exposed in public docs). The Codelabs source mentions
+  `replace_file_content` as a generic descriptor, not a confirmed tool name.
+- Subagent tool name — **LOW** (capability confirmed, exact API name unconfirmed in public docs).
+- No dedicated grep/content-search tool found; likely falls through to `Bash()` with `grep`.
+
+These tool names will be the basis for `skills/using-godot-prompter/references/antigravity-tools.md`
+in Task 13. Flag `Edit` and subagent names as "verify against official docs when available" in that file.
+
+## 8. Skill discovery — how Antigravity picks a skill
+
+Skills are loaded **progressively** (source:
+[agentpedia.codes Skills Setup Guide](https://agentpedia.codes/blog/antigravity-skills-setup-guide)):
+
+1. At startup, Antigravity **indexes only the frontmatter** of all skills in the workspace and global
+   directories. The body and `references/` files are not loaded into context.
+2. When the user's prompt semantically matches a skill's `description`, that skill is selected.
+3. The full SKILL.md body (and any explicitly referenced `references/` files) is loaded into context.
+
+**Priority:** workspace skills (`.agents/skills/`) override global skills with the same name.
+
+This matches Claude Code's behaviour exactly. GodotPrompter's 16 KB SKILL.md size budget (v1.7.0
+token-budget rule) applies equally to Antigravity — body is loaded on demand, not upfront.
+
+## 9. Recommended install path for GodotPrompter users
+
+**Recommendation: workspace symlink into `.agents/skills/`**
+
+```
+# From your Godot project root (Linux/macOS):
+mkdir -p .agents
+ln -s /path/to/GodotPrompter/skills .agents/skills
+
+# Windows (PowerShell, run as admin or with developer mode):
+New-Item -ItemType Junction -Path .agents\skills -Target D:\Godot\GodotPrompter\skills
+```
+
+Or global clone:
+
+```
+# Clone into global shared skills directory:
+git clone https://github.com/jame581/GodotPrompter ~/.gemini/skills/godot-prompter
+# Each skill folder becomes:  ~/.gemini/skills/godot-prompter/player-controller/SKILL.md
+```
+
+**No loader/manifest directory is needed.** Skills load directly from the skills directory by
+subdirectory-name + SKILL.md discovery. There is no `plugin.json` or index file required.
+
+**GodotPrompter layout is already compatible:** each skill lives in `skills/<skill-name>/SKILL.md`
+with the required `name:` and `description:` frontmatter. The only delta from the current Claude Code
+install path is the target directory name (`.agents/skills/` vs the user's own setup).
+
+The workspace symlink approach is preferred for active Godot development (skills stay up to date with
+git pull). The global clone is better for users who want GodotPrompter available across all projects.
+
+## 10. Unresolved items / gaps for Task 13
+
+1. **Edit tool exact name**: `Edit()` vs `Replace()` vs `replace_file_content`. Mark as "verify" in the
+   tool-mapping file.
+2. **Subagent tool name**: capability confirmed, API name not found in public docs.
+3. **Grep equivalent**: no dedicated tool found — likely `Bash("grep ...")`. Mark as such.
+4. **`~/.gemini/config/skills/` vs `~/.gemini/skills/`**: both cited; may be aliases. Safe to document
+   `~/.gemini/skills/` as primary.
+5. **GEMINI.md / project instructions**: GodotPrompter's `AGENTS.md` is not read by Antigravity. A note
+   for Antigravity users should be added to the `using-godot-prompter` skill (or a `.gemini/GEMINI.md`
+   should be added to the repo that re-exports the skill). Not blocking for Task 13 but worth flagging.
+6. **`tools:` frontmatter field**: GodotPrompter skills don't currently use it. No change needed, but
+   advanced users may want to scope Godot skills to specific MCP servers.
+
+## Sources
+
+- [Google Codelabs: Authoring Google Antigravity Skills](https://codelabs.developers.google.com/getting-started-with-antigravity-skills)
+- [Google Codelabs: Getting Started with Google Antigravity](https://codelabs.developers.google.com/getting-started-google-antigravity)
+- [Google Codelabs: Hands-on with Antigravity CLI](https://codelabs.developers.google.com/antigravity-cli-hands-on)
+- [Google Codelabs: Autonomous Dev Pipelines with Antigravity](https://codelabs.developers.google.com/autonomous-ai-developer-pipelines-antigravity)
+- [George Mao (Google Cloud Community): Deep Dive: Antigravity Agent Skills](https://medium.com/google-cloud/deep-dive-antigravity-agent-skills-b303bf05085b)
+- [George Mao (Google Cloud Community): How to Build Custom Skills in Google Antigravity](https://medium.com/google-cloud/tutorial-getting-started-with-antigravity-skills-864041811e0d)
+- [Dazbo / Deven Goratela: Configuring MCP Servers and Skills for Antigravity CLI and IDE](https://devengoratela.com/2026/05/configuring-mcp-servers-and-skills-for-antigravity-cli-and-ide/) — mirror of [Medium original](https://medium.com/google-cloud/configuring-mcp-servers-and-skills-for-antigravity-cli-and-ide-a938c7eebb78)
+- [agentpedia.codes: Antigravity Skills Setup Guide](https://agentpedia.codes/blog/antigravity-skills-setup-guide)
+- [agentpedia.codes: Antigravity CLI Deep Dive](https://agentpedia.codes/blog/antigravity-cli-deep-dive)
+- [TechCrunch: Google launches Antigravity 2.0 at IO 2026](https://techcrunch.com/2026/05/19/google-launches-antigravity-2-0-with-an-updated-desktop-app-and-cli-tool-at-io-2026/)
+- [MCP Directory: How to Use Antigravity Skills](https://mcpdirectory.app/blog/how-to-use-antigravity-skills-2026)

--- a/docs/superpowers/notes/2026-06-17-antigravity-research.md
+++ b/docs/superpowers/notes/2026-06-17-antigravity-research.md
@@ -70,17 +70,19 @@ explicitly tested all of them:
 
 **Resolution:**
 
-- `~/.gemini/skills/` is the **recommended global path** for skills shared across all Antigravity tools.
-  Confirmed by both George Mao (Google Cloud Community) and Dazbo's live test.
-- `~/.gemini/config/skills/` is cited in an official codelab — functionally equivalent to
-  `~/.gemini/skills/` or a valid alternative config sub-path. Treat as a valid alias until confirmed
-  otherwise.
+- `~/.gemini/config/skills/` is the **official-documented global path**, specified explicitly in the
+  Google Codelabs "Getting Started with Google Antigravity" codelab: "Global Scope
+  (`~/.gemini/config/skills/`): Available across all Antigravity products (Antigravity, Antigravity IDE,
+  Antigravity CLI) and projects."
+- `~/.gemini/skills/` is a **community-verified alias** — confirmed working by both George Mao (Google
+  Cloud Community) and Dazbo's live test. Reported to work in practice, but not the path the official
+  codelab names.
 - `~/.gemini/antigravity-cli/skills/` is CLI-specific only.
 - `~/.gemini/antigravity/skills/` is **confirmed incorrect** by Dazbo's live testing — skills placed
   there are not picked up.
 
-**Confidence: HIGH** that `~/.gemini/skills/` is the right shared global path.
-**Confidence: MEDIUM** on `~/.gemini/config/skills/` being an equivalent alias.
+**Confidence: HIGH** that `~/.gemini/config/skills/` is the correct shared global path (official Codelab source).
+**Confidence: MEDIUM** that `~/.gemini/skills/` works as an alias (community-verified, Dazbo live test).
 
 ## 4. SKILL.md frontmatter fields
 
@@ -209,13 +211,23 @@ ln -s /path/to/GodotPrompter/skills .agents/skills
 New-Item -ItemType Junction -Path .agents\skills -Target D:\Godot\GodotPrompter\skills
 ```
 
-Or global clone:
+Or global install:
 
 ```
-# Clone into global shared skills directory:
-git clone https://github.com/jame581/GodotPrompter ~/.gemini/skills/godot-prompter
-# Each skill folder becomes:  ~/.gemini/skills/godot-prompter/player-controller/SKILL.md
+# Symlink individual skill folders so each is a direct child of the skills dir (recommended):
+ln -s /path/to/GodotPrompter/skills/* ~/.gemini/config/skills/
+# Each skill folder becomes:  ~/.gemini/config/skills/player-controller/SKILL.md
+
+# Alternative — clone the whole repo (but see nesting caveat below):
+git clone https://github.com/jame581/GodotPrompter ~/.gemini/config/skills/godot-prompter
+# Each skill folder becomes:  ~/.gemini/config/skills/godot-prompter/player-controller/SKILL.md
 ```
+
+> **Nesting caveat (open verify-item):** If Antigravity discovers skills as immediate subdirectories of
+> the skills dir (`<skills-dir>/<skill-name>/SKILL.md`), the clone approach nests skills one level too
+> deep and they may not be picked up. Prefer the `ln -s skills/*` form so each skill is a direct child,
+> or confirm that nested discovery (`<skills-dir>/<repo>/skills/<skill>/SKILL.md`) actually works before
+> recommending the clone path.
 
 **No loader/manifest directory is needed.** Skills load directly from the skills directory by
 subdirectory-name + SKILL.md discovery. There is no `plugin.json` or index file required.
@@ -233,8 +245,9 @@ git pull). The global clone is better for users who want GodotPrompter available
    tool-mapping file.
 2. **Subagent tool name**: capability confirmed, API name not found in public docs.
 3. **Grep equivalent**: no dedicated tool found — likely `Bash("grep ...")`. Mark as such.
-4. **`~/.gemini/config/skills/` vs `~/.gemini/skills/`**: both cited; may be aliases. Safe to document
-   `~/.gemini/skills/` as primary.
+4. **`~/.gemini/config/skills/` vs `~/.gemini/skills/`**: codelab names `~/.gemini/config/skills/` as
+   official; `~/.gemini/skills/` is a community-verified alias. Document `~/.gemini/config/skills/` as
+   primary in Task 13 tool-mapping file.
 5. **GEMINI.md / project instructions**: GodotPrompter's `AGENTS.md` is not read by Antigravity. A note
    for Antigravity users should be added to the `using-godot-prompter` skill (or a `.gemini/GEMINI.md`
    should be added to the repo that re-exports the skill). Not blocking for Task 13 but worth flagging.

--- a/docs/superpowers/notes/2026-06-17-antigravity-research.md
+++ b/docs/superpowers/notes/2026-06-17-antigravity-research.md
@@ -267,3 +267,11 @@ git pull). The global clone is better for users who want GodotPrompter available
 - [agentpedia.codes: Antigravity CLI Deep Dive](https://agentpedia.codes/blog/antigravity-cli-deep-dive)
 - [TechCrunch: Google launches Antigravity 2.0 at IO 2026](https://techcrunch.com/2026/05/19/google-launches-antigravity-2-0-with-an-updated-desktop-app-and-cli-tool-at-io-2026/)
 - [MCP Directory: How to Use Antigravity Skills](https://mcpdirectory.app/blog/how-to-use-antigravity-skills-2026)
+
+## Verification result (2026-06-17) — Task 16
+
+**Status: FORMAT-VERIFIED, RUNTIME-PENDING.**
+
+- **Format verification (done):** Antigravity's documented Agent Skill format — a `SKILL.md` with `name` + `description` frontmatter plus a `references/` subfolder for load-on-demand material — is identical to GodotPrompter's existing skill structure. GodotPrompter skills therefore require no structural change to load in Antigravity. The tool-name mapping (`skills/using-godot-prompter/references/antigravity-tools.md`) and install paths are grounded in the sources above.
+- **Runtime verification (NOT done):** No Antigravity install exists on the v1.10.0 dev machine. Checked `~/.gemini` (absent), `%LOCALAPPDATA%\Programs\Antigravity`, `%LOCALAPPDATA%\Antigravity`, `C:\Program Files\Antigravity`, and `antigravity` on PATH — none present. Discovery + invocation in a live Antigravity install was therefore NOT exercised.
+- **Carried-forward open items for a future release** (do not claim as verified): (1) the exact file-edit / subagent-dispatch / content-search tool names (marked unconfirmed in `antigravity-tools.md`); (2) whether global skill discovery accepts nested clones or requires flat per-skill subdirectories (the clone-nesting caveat); (3) confirmation that `references/` subfolders resolve identically at runtime. Install docs (`antigravity-tools.md`, `using-godot-prompter/SKILL.md`) are labeled with these caveats rather than overclaiming.

--- a/docs/superpowers/notes/2026-06-17-beehave-research.md
+++ b/docs/superpowers/notes/2026-06-17-beehave-research.md
@@ -1,0 +1,630 @@
+# Beehave — Godot 4.x Research Digest (for the `beehave` skill)
+
+> Gathered 2026-06-17 from the local clone at `D:/Godot/_addon-src/beehave` pinned to **v2.9.2**.
+> Primary source: GDScript under `addons/beehave/` — `blackboard.gd`, `nodes/**/*.gd`,
+> `debug/`, `metrics/`, `plugin.cfg`, `plugin.gd`. Cross-checked with the repo README.
+> **Beehave is GDScript-only. No official C# API exists.** (Confirmed: zero `.cs` files in
+> `addons/beehave/`; the one `.cs` file in the repo belongs to the gdUnit4 test addon, not Beehave.)
+
+---
+
+## 1. Release metadata
+
+| Field | Value |
+|---|---|
+| Version | **2.9.2** (tag `v2.9.2`) |
+| Godot compatibility | 4.1.x for v2.9.x; 4.0.x for v2.7.x (from README table) |
+| Minimum Godot | Godot 4 (`config_version=5` in project.godot; `config/features=PackedStringArray("4.5")` in demo project) |
+| License | MIT (`addons/beehave/LICENSE`) |
+| Author | bitbrain |
+| Plugin name | `Beehave` (`plugin.cfg`) |
+| Autoloads added | `BeehaveGlobalMetrics`, `BeehaveGlobalDebugger` |
+
+Install path: clone or copy `addons/beehave/` into the project's `addons/` folder.
+Enable via **Project > Project Settings > Plugins**. Copy `script_templates/` into the project root.
+Also available on the Godot Asset Library.
+
+---
+
+## 2. Return codes (enum on `BeehaveNode`)
+
+Defined verbatim in `beehave_node.gd` (and mirrored in `beehave_tree.gd`):
+
+```
+enum { SUCCESS, FAILURE, RUNNING }
+# SUCCESS = 0, FAILURE = 1, RUNNING = 2  (int enum, untyped)
+```
+
+Every node that overrides `tick()` must return one of these three int values.
+
+---
+
+## 3. `BeehaveNode` — base class
+
+File: `nodes/beehave_node.gd`
+
+```
+class_name BeehaveNode extends Node
+
+# Core overridable lifecycle methods:
+func tick(actor: Node, blackboard: Blackboard) -> int       # override; returns SUCCESS/FAILURE/RUNNING
+func interrupt(actor: Node, blackboard: Blackboard) -> void # called when tree interrupts this node
+func before_run(actor: Node, blackboard: Blackboard) -> void  # called before first tick of a run
+func after_run(actor: Node, blackboard: Blackboard) -> void   # called after tick returns SUCCESS or FAILURE
+
+# Internal:
+func _safe_tick(actor: Node, blackboard: Blackboard) -> int  # validates tick() return type; returns FAILURE on bad type
+func can_send_message(blackboard: Blackboard) -> bool        # true when debugger tab is visible
+func get_class_name() -> Array[StringName]                   # returns [&"BeehaveNode"]
+```
+
+All nodes are `@tool` — they run in the Godot editor for configuration warnings.
+
+---
+
+## 4. `BeehaveTree` — tree root
+
+File: `nodes/beehave_tree.gd`
+
+```
+class_name BeehaveTree extends Node
+
+enum ProcessThread { IDLE, PHYSICS, MANUAL }
+
+# Exported properties:
+@export var enabled: bool = true          # enables/disables ticking; emits tree_enabled / tree_disabled
+@export var tick_rate: int = 1            # tick every N frames (1 = every frame)
+@export_node_path var actor_node_path: NodePath  # target actor; defaults to get_parent()
+@export var process_thread: ProcessThread = ProcessThread.PHYSICS  # IDLE, PHYSICS, or MANUAL
+@export var blackboard: Blackboard        # optional external Blackboard; auto-creates internal if not set
+@export var custom_monitor: bool = false  # registers tree in Performance monitor
+@export var actor: Node                   # the actor node (set from actor_node_path or parent)
+
+# Signals:
+signal tree_enabled
+signal tree_disabled
+
+# Methods:
+func tick() -> int                        # manually tick if process_thread == MANUAL; returns status int
+func enable() -> void                     # sets enabled = true
+func disable() -> void                    # sets enabled = false
+func interrupt() -> void                  # interrupts tree if something is running
+func get_running_action() -> ActionLeaf   # returns currently running ActionLeaf or null
+func get_last_condition() -> ConditionLeaf          # returns last evaluated ConditionLeaf or null
+func get_last_condition_status() -> String          # returns "SUCCESS", "FAILURE", or "RUNNING"
+
+# State:
+var status: int = -1      # last returned status code
+var last_tick: int = -1   # internal frame counter for tick_rate throttle
+```
+
+`BeehaveTree` must have **exactly one** BeehaveNode child (the root composite or decorator).
+It auto-creates an internal `Blackboard` if none is exported.
+
+---
+
+## 5. `Blackboard`
+
+File: `blackboard.gd`
+
+```
+class_name Blackboard extends Node
+
+const DEFAULT = "default"
+
+@export var blackboard: Dictionary = {}   # pre-populated key-value pairs (exported for inspector)
+
+# Methods:
+func set_value(key: Variant, value: Variant, blackboard_name: String = DEFAULT) -> void
+func get_value(key: Variant, default_value: Variant = null, blackboard_name: String = DEFAULT) -> Variant
+func has_value(key: Variant, blackboard_name: String = DEFAULT) -> bool
+func erase_value(key: Variant, blackboard_name: String = DEFAULT) -> void
+func keys() -> Array[String]
+func get_debug_data() -> Dictionary   # sanitized dict safe to send over EngineDebugger
+```
+
+The `blackboard_name` param (default `"default"`) allows multiple named namespaces on the same
+Blackboard node. Actor-scoped internal state uses `str(actor.get_instance_id())` as the name.
+
+`erase_value` sets the key to `null` (does not delete the key from the dict). `has_value` returns
+`false` if the value is `null`, so erasing correctly hides a key from `has_value`.
+
+---
+
+## 6. Composites
+
+### Base class: `Composite extends BeehaveNode`
+
+File: `nodes/composites/composite.gd`
+
+```
+class_name Composite extends BeehaveNode
+var running_child: BeehaveNode = null   # tracks which child is currently RUNNING
+```
+
+Has `interrupt()`, `after_run()`, and internal helpers `_cleanup_running()` / `_interrupt_children()`.
+
+---
+
+### `SequenceComposite` (AND logic)
+
+File: `nodes/composites/sequence.gd`
+
+```
+class_name SequenceComposite extends Composite
+```
+
+Ticks children left-to-right. Returns `SUCCESS` only if **all** children return `SUCCESS`.
+Returns `FAILURE` on the first child `FAILURE` (resets successful_index to 0).
+Returns `RUNNING` if a child is `RUNNING` (resumes at that child next tick, skips already-succeeded children).
+
+---
+
+### `SequenceReactiveComposite` (reactive AND)
+
+File: `nodes/composites/sequence_reactive.gd`
+
+```
+class_name SequenceReactiveComposite extends Composite
+```
+
+Like `SequenceComposite` but re-evaluates from the **first child every tick**, even while RUNNING.
+Suitable for conditions that can change mid-action.
+
+---
+
+### `SequenceStarComposite` (memory AND)
+
+File: `nodes/composites/sequence_star.gd`
+
+```
+class_name SequenceStarComposite extends Composite
+```
+
+Like `SequenceComposite` but does NOT reset `successful_index` on FAILURE — resumes from where
+it left off on FAILURE as well as RUNNING.
+
+---
+
+### `SelectorComposite` (OR logic)
+
+File: `nodes/composites/selector.gd`
+
+```
+class_name SelectorComposite extends Composite
+```
+
+Ticks children left-to-right. Returns `SUCCESS` on the first child that returns `SUCCESS`.
+Returns `FAILURE` only if **all** children return `FAILURE`. Returns `RUNNING` if a child is `RUNNING`.
+Skips already-failed children across ticks (`last_execution_index`).
+
+---
+
+### `SelectorReactiveComposite` (reactive OR)
+
+File: `nodes/composites/selector_reactive.gd`
+
+```
+class_name SelectorReactiveComposite extends Composite
+```
+
+Like `SelectorComposite` but re-evaluates from the **first child every tick** while RUNNING.
+
+---
+
+### `SimpleParallelComposite`
+
+File: `nodes/composites/simple_parallel.gd`
+
+```
+class_name SimpleParallelComposite extends Composite
+
+@export var secondary_node_repeat_count: int = 0   # 0 = loop secondary forever
+@export var delay_mode: bool = false               # wait for secondary to finish after primary ends
+```
+
+Requires **exactly two** children: child 0 = primary, child 1 = secondary.
+Always reports the primary child's status. Secondary runs alongside primary regardless of primary's result.
+If `delay_mode = true`, waits for secondary's current tick to complete after primary finishes.
+
+---
+
+### `SequenceRandomComposite`
+
+File: `nodes/composites/sequence_random.gd`
+
+```
+class_name SequenceRandomComposite extends RandomizedComposite
+
+signal reset(new_order: Array[Node])   # emitted when children are reshuffled
+
+@export var resume_on_failure: bool = false    # if true, keeps current shuffle on failure
+@export var resume_on_interrupt: bool = false  # if true, keeps current shuffle on interrupt
+```
+
+Executes children in a random shuffled order. Inherits `RandomizedComposite` weight support.
+
+---
+
+### `SelectorRandomComposite`
+
+File: `nodes/composites/selector_random.gd`
+
+```
+class_name SelectorRandomComposite extends RandomizedComposite
+```
+
+Tries children in random shuffled order; returns `SUCCESS` on first success, `FAILURE` if all fail.
+
+---
+
+### `RandomizedComposite` (shared base for random composites)
+
+File: `nodes/composites/randomized_composite.gd`
+
+```
+class_name RandomizedComposite extends Composite
+
+@export var random_seed: int = 0       # 0 = randomize(); nonzero = seed(random_seed)
+@export var use_weights: bool          # if true, exposes per-child "Weights/<name>" int (1-100) properties
+
+func get_shuffled_children() -> Array[Node]   # returns shuffled children array (weighted or uniform)
+```
+
+---
+
+## 7. Decorators
+
+### Base class: `Decorator extends BeehaveNode`
+
+File: `nodes/decorators/decorator.gd`
+
+```
+class_name Decorator extends BeehaveNode
+var running_child: BeehaveNode = null
+```
+
+Must have **exactly one** child node.
+
+---
+
+### `InverterDecorator`
+
+File: `nodes/decorators/inverter.gd`
+
+```
+class_name InverterDecorator extends Decorator
+```
+
+Flips `SUCCESS` ↔ `FAILURE`. Passes `RUNNING` through unchanged.
+
+---
+
+### `AlwaysFailDecorator`
+
+File: `nodes/decorators/failer.gd`
+
+```
+class_name AlwaysFailDecorator extends Decorator
+```
+
+**Note:** The brief calls this `FailerDecorator` but the actual class_name is `AlwaysFailDecorator`.
+Always returns `FAILURE` (passes `RUNNING` through).
+
+---
+
+### `AlwaysSucceedDecorator`
+
+File: `nodes/decorators/succeeder.gd`
+
+```
+class_name AlwaysSucceedDecorator extends Decorator
+```
+
+**Note:** The brief calls this `SucceederDecorator` but the actual class_name is `AlwaysSucceedDecorator`.
+Always returns `SUCCESS` (passes `RUNNING` through).
+
+---
+
+### `LimiterDecorator`
+
+File: `nodes/decorators/limiter.gd`
+
+```
+class_name LimiterDecorator extends Decorator
+
+@export var max_count: int = 0   # max number of RUNNING ticks before returning FAILURE
+```
+
+Allows its child to be ticked at most `max_count` times while `RUNNING`. After that returns `FAILURE`.
+Counter resets when child finishes (not RUNNING) or when interrupted.
+
+---
+
+### `CooldownDecorator`
+
+File: `nodes/decorators/cooldown.gd`
+
+```
+class_name CooldownDecorator extends Decorator
+
+@export var wait_time := 0.0   # cooldown duration in seconds
+```
+
+After child executes (non-RUNNING result), blocks re-execution for `wait_time` seconds by returning
+`FAILURE` during cooldown. Uses `Time.get_ticks_msec()` internally. Resets on interrupt.
+
+---
+
+### `TimeLimiterDecorator`
+
+File: `nodes/decorators/time_limiter.gd`
+
+```
+class_name TimeLimiterDecorator extends Decorator
+
+@export var wait_time := 0.0   # time budget in seconds
+```
+
+Gives child `wait_time` seconds to finish. If still `RUNNING` after that, interrupts and returns `FAILURE`.
+Timer tracked via `get_physics_process_delta_time()` accumulated in the Blackboard. Resets on `before_run`
+or interrupt.
+
+---
+
+### `DelayDecorator`
+
+File: `nodes/decorators/delayer.gd`
+
+```
+class_name DelayDecorator extends Decorator
+
+@export var wait_time := 0.0   # delay in seconds before executing child
+```
+
+Returns `RUNNING` for `wait_time` seconds before first executing the child. Timer resets when
+child is no longer RUNNING or on interrupt.
+
+---
+
+### `RepeaterDecorator`
+
+File: `nodes/decorators/repeater.gd`
+
+```
+class_name RepeaterDecorator extends Decorator
+
+@export var repetitions: int = 1   # number of times child must return SUCCESS before this returns SUCCESS
+```
+
+Executes child until it succeeds `repetitions` times. Returns `FAILURE` immediately if child fails.
+Returns `RUNNING` while looping. Counter resets on `before_run` and interrupt.
+**Note:** `get_class_name()` in this file returns `&"LimiterDecorator"` — this is a bug in the source
+(a copy-paste error). The actual GDScript class is `RepeaterDecorator`.
+
+---
+
+### `UntilFailDecorator`
+
+File: `nodes/decorators/until_fail.gd`
+
+```
+class_name UntilFailDecorator extends Decorator
+```
+
+Returns `RUNNING` as long as child returns `SUCCESS` or `RUNNING`. Returns `SUCCESS` when child
+finally returns `FAILURE`. (Loop until the child fails.)
+
+---
+
+## 8. Leaves
+
+### Base class chain: `Leaf extends BeehaveNode` → `ActionLeaf extends Leaf` / `ConditionLeaf extends Leaf`
+
+Files: `nodes/leaves/leaf.gd`, `action.gd`, `condition.gd`
+
+```
+class_name Leaf extends BeehaveNode
+# leaf nodes must not have BeehaveNode children (editor warning if they do)
+
+class_name ActionLeaf extends Leaf
+# long-running tasks; may return RUNNING across multiple frames
+
+class_name ConditionLeaf extends Leaf
+# single-frame checks; should never return RUNNING
+```
+
+**The leaf contract** — override `tick(actor: Node, blackboard: Blackboard) -> int`:
+- Return `SUCCESS` when the action/condition is satisfied or complete.
+- Return `FAILURE` when the action/condition is not satisfied or failed.
+- Return `RUNNING` (ActionLeaf only) when the task needs more frames to complete.
+
+Leaf files declare `EXPRESSION_PLACEHOLDER: String = "Insert an expression..."` — used by built-in
+expression leaves (see section 9).
+
+---
+
+## 9. Built-in expression leaves
+
+These are ready-to-use nodes (no GDScript required) that evaluate GDScript expressions against the Blackboard.
+
+### `BlackboardSetAction extends ActionLeaf`
+
+File: `nodes/leaves/blackboard_set.gd`
+
+```
+class_name BlackboardSetAction extends ActionLeaf
+
+@export_placeholder(...) var key: String = ""     # GDScript expression for the key
+@export_placeholder(...) var value: String = ""   # GDScript expression for the value
+# Returns SUCCESS; FAILURE if expression fails
+```
+
+### `BlackboardEraseAction extends ActionLeaf`
+
+File: `nodes/leaves/blackboard_erase.gd`
+
+```
+class_name BlackboardEraseAction extends ActionLeaf
+
+@export_placeholder(...) var key: String = ""   # expression for the key to erase
+# Returns SUCCESS; FAILURE if expression fails
+```
+
+### `BlackboardHasCondition extends ConditionLeaf`
+
+File: `nodes/leaves/blackboard_has.gd`
+
+```
+class_name BlackboardHasCondition extends ConditionLeaf
+
+@export_placeholder(...) var key: String = ""   # expression for the key to check
+# Returns SUCCESS if key exists and is non-null; FAILURE otherwise
+```
+
+### `BlackboardCompareCondition extends ConditionLeaf`
+
+File: `nodes/leaves/blackboard_compare.gd`
+
+```
+class_name BlackboardCompareCondition extends ConditionLeaf
+
+enum Operators { EQUAL, NOT_EQUAL, GREATER, LESS, GREATER_EQUAL, LESS_EQUAL }
+
+@export_placeholder(...) var left_operand: String = ""   # GDScript expression
+@export_enum("==", "!=", ">", "<", ">=", "<=") var operator: int = 0
+@export_placeholder(...) var right_operand: String = ""  # GDScript expression
+# Returns SUCCESS if comparison is true; FAILURE on expression error or false comparison
+```
+
+Expression strings run via Godot's `Expression.execute([], blackboard)` — the blackboard itself
+is the base instance, so expressions can call `get_value("key")` directly.
+
+---
+
+## 10. Visual debugger
+
+Files: `debug/debugger.gd`, `debug/global_debugger.gd`, `debug/debugger_messages.gd`
+
+The debugger is an `EditorDebuggerPlugin` registered by `plugin.gd` on `_enter_tree`.
+Two autoloads handle runtime state:
+- `BeehaveGlobalDebugger` (`global_debugger.gd`) — singleton on the running game side; listens for
+  `"beehave:activate_tree"` and `"beehave:visibility_changed"` from the editor via `EngineDebugger`.
+- `BeehaveGlobalMetrics` (`metrics/beehave_global_metrics.gd`) — exposes two Performance monitors:
+  `"beehave/total_trees"` and `"beehave/total_enabled_trees"`.
+
+**Enabling the debugger tab:**
+- Plugin adds a `"🐝 Beehave"` tab in the bottom editor panel (Debugger section).
+- Select a running tree in the tab to activate it; only one tree is active at a time.
+- Optional floating window: click the detach button in the tab (or set project setting
+  `beehave/debugger/start_detached = true` to start detached by default).
+
+**Per-tree custom Performance monitor:**
+- Set `custom_monitor = true` on a `BeehaveTree` to register
+  `"beehave [microseconds]/process_time_<actor_name>-<id>"` in the Performance panel.
+
+**How it works at runtime:**
+- Each `BeehaveTree` calls `BeehaveDebuggerMessages.process_begin/tick/end/interrupt()` via
+  `EngineDebugger.send_message("beehave:...", [...])` — only when the debugger tab is visible
+  and the tree is the active tree (`_can_send_message == true`).
+- The editor-side `BeehaveEditorDebugger._capture()` handles `beehave:*` prefixed messages and
+  updates the graph UI.
+
+---
+
+## 11. GDScript-only confirmation
+
+**Beehave is GDScript-only.** There are zero `.cs` files in `addons/beehave/`.
+
+The only `.cs` file in the entire repository (`addons/gdUnit4/src/dotnet/GdUnit4CSharpApi.cs`) belongs
+to the gdUnit4 testing framework bundled in the demo project, not to Beehave itself.
+
+There is no official C# wrapper or C# port of Beehave. Users wishing to use Beehave from C#
+can call the GDScript API via Godot's cross-language interop (e.g. `GetNode<BeehaveTree>().Call("tick")`),
+but Beehave provides no typed C# classes or interfaces.
+
+**Skill author implication:** the validator allowlist for the `beehave` skill must mark C# examples
+as skill-authored, not doc-sourced. The skill itself should be GDScript-only with a note that
+no official C# API exists (pattern identical to how we handle addon-specific content).
+
+---
+
+## 12. Class-name discrepancies (source vs. common names)
+
+The brief uses some names that differ from actual `class_name` declarations:
+
+| Common name | Actual `class_name` in source |
+|---|---|
+| `FailerDecorator` | `AlwaysFailDecorator` |
+| `SucceederDecorator` | `AlwaysSucceedDecorator` |
+| `RepeaterDecorator` | `RepeaterDecorator` (correct) — but `get_class_name()` erroneously returns `&"LimiterDecorator"` (copy-paste bug in v2.9.2 source) |
+
+The skill must use the actual `class_name` values since that is what Godot's autocomplete and `is`
+checks will see: `AlwaysFailDecorator`, `AlwaysSucceedDecorator`.
+
+---
+
+## 13. Node hierarchy diagram
+
+```
+BeehaveNode (base)
+  ├── BeehaveTree            (tree root; not ticked by parent)
+  ├── Composite
+  │     ├── SequenceComposite
+  │     ├── SequenceReactiveComposite
+  │     ├── SequenceStarComposite
+  │     ├── SelectorComposite
+  │     ├── SelectorReactiveComposite
+  │     ├── SimpleParallelComposite
+  │     └── RandomizedComposite
+  │           ├── SequenceRandomComposite
+  │           └── SelectorRandomComposite
+  ├── Decorator
+  │     ├── InverterDecorator
+  │     ├── AlwaysFailDecorator
+  │     ├── AlwaysSucceedDecorator
+  │     ├── LimiterDecorator
+  │     ├── CooldownDecorator
+  │     ├── TimeLimiterDecorator
+  │     ├── DelayDecorator
+  │     ├── RepeaterDecorator
+  │     └── UntilFailDecorator
+  └── Leaf
+        ├── ActionLeaf
+        │     ├── BlackboardSetAction
+        │     └── BlackboardEraseAction
+        └── ConditionLeaf
+              ├── BlackboardHasCondition
+              └── BlackboardCompareCondition
+```
+
+---
+
+## Doc-coverage flags for skill author
+
+1. **C# parity** — does not exist; Beehave is GDScript-only. The skill must not include C# examples
+   and should include a "C# note" explaining the limitation (cross-language call via `Call()` only).
+   This is a validator allowlist decision: the `beehave` skill should be listed in the validator's
+   GDScript-only exception list (alongside gdextension).
+
+2. **`MANUAL` process thread** — `tick()` is exposed publicly for manual invocation, but the README
+   and wiki do not document a worked example. The skill should author a short example for
+   `process_thread = MANUAL` + calling `tree.tick()` from a parent script.
+
+3. **Sharing a single `Blackboard` across multiple trees** — a common pattern (one Blackboard node
+   exported to multiple BeehaveTrees on the same actor). Not explicitly documented in README/wiki;
+   the skill should author this pattern from the `@export var blackboard: Blackboard` API.
+
+4. **Weight-based random composites** — `RandomizedComposite.use_weights` and the `Weights/<name>`
+   per-child properties are configured via the inspector (dynamic property list); not easily
+   represented in code. Skill should note this is inspector-only configuration.
+
+5. **`RepeaterDecorator` `get_class_name()` bug** — returns `&"LimiterDecorator"` in v2.9.2 source.
+   This means `node.get_class_name()` checks will return the wrong value for `RepeaterDecorator`.
+   Flag as a known bug; do not paper over it in the skill.
+
+6. **Process thread default is PHYSICS** — `tick()` runs in `_physics_process`. If the game uses
+   `_process` for the actor, set `process_thread = IDLE`. The skill should call this out.
+
+7. **`tick_rate` throttling** — `tick_rate = 1` means every frame; `tick_rate = 3` = every 3 frames.
+   Useful for optimizing AI-heavy scenes. Author a short note with an example value.

--- a/docs/superpowers/notes/2026-06-17-beehave-research.md
+++ b/docs/superpowers/notes/2026-06-17-beehave-research.md
@@ -54,7 +54,7 @@ func after_run(actor: Node, blackboard: Blackboard) -> void   # called after tic
 
 # Internal:
 func _safe_tick(actor: Node, blackboard: Blackboard) -> int  # validates tick() return type; returns FAILURE on bad type
-func can_send_message(blackboard: Blackboard) -> bool        # true when debugger tab is visible
+func can_send_message(blackboard: Blackboard) -> bool        # true when debugger tab is visible; blackboard value set per-tick by BeehaveTree
 func get_class_name() -> Array[StringName]                   # returns [&"BeehaveNode"]
 ```
 
@@ -63,6 +63,8 @@ All nodes are `@tool` — they run in the Godot editor for configuration warning
 ---
 
 ## 4. `BeehaveTree` — tree root
+
+**Important:** `BeehaveTree extends Node`, NOT `BeehaveNode`. An `is BeehaveNode` check on a tree instance returns `false`.
 
 File: `nodes/beehave_tree.gd`
 
@@ -568,7 +570,6 @@ checks will see: `AlwaysFailDecorator`, `AlwaysSucceedDecorator`.
 
 ```
 BeehaveNode (base)
-  ├── BeehaveTree            (tree root; not ticked by parent)
   ├── Composite
   │     ├── SequenceComposite
   │     ├── SequenceReactiveComposite
@@ -596,6 +597,8 @@ BeehaveNode (base)
         └── ConditionLeaf
               ├── BlackboardHasCondition
               └── BlackboardCompareCondition
+
+BeehaveTree (tree root; extends Node NOT BeehaveNode; not ticked by parent)
 ```
 
 ---

--- a/docs/superpowers/notes/2026-06-17-limboai-research.md
+++ b/docs/superpowers/notes/2026-06-17-limboai-research.md
@@ -1,0 +1,713 @@
+# LimboAI — Godot 4.x Research Digest (for the `limboai` skill)
+
+> Gathered 2026-06-17 from the local clone at `D:/Godot/_addon-src/limboai` pinned to tag **v1.7.1**.
+> Primary sources: `doc_classes/*.xml` (verbatim class reference), `doc/source/**/*.rst` (tutorial docs),
+> `demo/demo/**/*.gd` (example tasks and states), `gdextension/limboai.gdextension` (install config).
+> Cross-checked with https://limboai.readthedocs.io/en/v1.7.1/.
+
+## 1. Release metadata
+
+| Field              | Value                                            |
+|--------------------|--------------------------------------------------|
+| **Version**        | 1.7.1 (`limboai_version.py`: major=1, minor=7, patch=1) |
+| **Min Godot (GDExtension)** | 4.6 (v1.7.x per README compatibility table; `gdextension/limboai.gdextension` sets `compatibility_minimum = "4.2"` but the README explicitly states Godot 4.6 for v1.7.x) |
+| **Min Godot (module)** | 4.6                                         |
+| **License**        | MIT — "Copyright (c) 2023-2025 Serhii Snitsaruk and the LimboAI contributors" |
+| **Repo**           | https://github.com/limbonaut/limboai            |
+
+## 2. Install paths
+
+### GDExtension (recommended — no custom engine required)
+
+1. Godot AssetLib → search "LimboAI" → Download. Reload project.
+2. Or download from GitHub Releases, place the `addons/limboai/` folder in `res://addons/limboai/`.
+3. The `.gdextension` file ships at `res://addons/limboai/bin/` with platform entries:
+
+```ini
+[configuration]
+entry_symbol = "limboai_init"
+compatibility_minimum = "4.2"
+
+[libraries]
+macos.debug    = "res://addons/limboai/bin/liblimboai.macos.editor.framework"
+macos.release  = "res://addons/limboai/bin/liblimboai.macos.template_release.framework"
+windows.debug.x86_64   = "res://addons/limboai/bin/liblimboai.windows.editor.x86_64.dll"
+windows.release.x86_64 = "res://addons/limboai/bin/liblimboai.windows.template_release.x86_64.dll"
+linux.debug.x86_64     = "res://addons/limboai/bin/liblimboai.linux.editor.x86_64.so"
+linux.release.x86_64   = "res://addons/limboai/bin/liblimboai.linux.template_release.x86_64.so"
+# ... also: linux arm64/rv64, android arm32/arm64/x86_32/x86_64, iOS, web
+```
+
+**GDExtension limitations:** no in-editor documentation tooltips; `BBParam` property editor not available.
+
+### Module version (custom engine build)
+
+Download pre-compiled editor + export templates from GitHub Releases. Requires custom engine for export.
+Module version has full editor integration and slightly better performance.
+
+## 3. Core classes
+
+### 3.1 `BT` (base `Resource`) — status constants
+
+```gdscript
+# BT.Status enum (defined in BT.xml):
+BT.FRESH   = 0  # Task wasn't executed yet or was aborted/reset
+BT.RUNNING = 1  # Task is being performed and hasn't finished yet
+BT.FAILURE = 2  # Task has finished with failure
+BT.SUCCESS = 3  # Task has finished with success
+```
+
+In task scripts, use the shorthand constants `SUCCESS`, `FAILURE`, `RUNNING` (available without prefix inside a BTTask subclass).
+
+### 3.2 `BehaviorTree` (`Resource`)
+
+`BehaviorTree` is a **saved `.tres` / `.res` resource** edited in the LimboAI editor panel.
+
+| Member | Type | Notes |
+|---|---|---|
+| `blackboard_plan` | `BlackboardPlan` | Variable schema for new Blackboard instances |
+| `description` | `String` | User-provided description (default `""`) |
+
+| Method | Signature | Notes |
+|---|---|---|
+| `get_root_task()` | `-> BTTask` | Returns root task of the resource |
+| `set_root_task(task)` | `(BTTask)` | Assigns a new root task |
+| `instantiate(agent, blackboard, instance_owner, custom_scene_root=null)` | `-> BTInstance` | Creates a runtime BTInstance; `instance_owner` is typically the BTPlayer/BTState node; `custom_scene_root` overrides `instance_owner.owner` |
+| `clone()` | `-> BehaviorTree` | Makes a copy of the resource |
+| `copy_other(other)` | `(BehaviorTree)` | Become a copy of another BT |
+
+Signals: `branch_changed(branch: BTTask)` (editor only), `plan_changed`.
+
+### 3.3 `BTPlayer` (`Node`)
+
+`BTPlayer` executes a `BehaviorTree` resource at runtime. Add it as a child of the agent node.
+
+| Property | Type | Default | Notes |
+|---|---|---|---|
+| `behavior_tree` | `BehaviorTree` | — | The BT resource to execute |
+| `blackboard` | `Blackboard` | — | Shared data for tasks; set after init |
+| `blackboard_plan` | `BlackboardPlan` | — | Variable overrides per-scene |
+| `active` | `bool` | `true` | When `false`, BT is not executed; init is deferred until activation |
+| `agent_node` | `NodePath` | `NodePath("..")` | Path to the agent (defaults to parent) |
+| `update_mode` | `BTPlayer.UpdateMode` | `PHYSICS` (1) | See enum below |
+| `monitor_performance` | `bool` | `false` | Adds Debugger→Monitors entry |
+
+`BTPlayer.UpdateMode` enum:
+```gdscript
+BTPlayer.IDLE    = 0  # Execute during _process
+BTPlayer.PHYSICS = 1  # Execute during _physics_process
+BTPlayer.MANUAL  = 2  # Call update(delta) manually
+```
+
+| Method | Signature | Notes |
+|---|---|---|
+| `update(delta)` | `(float)` | Manual tick — only call when `update_mode == MANUAL` |
+| `restart()` | `-> void` | Resets execution; does NOT reset Blackboard |
+| `get_bt_instance()` | `-> BTInstance` | Returns the live BTInstance |
+| `set_bt_instance(bt_instance)` | `(BTInstance)` | Swap to a different BT instance at runtime |
+| `set_scene_root_hint(scene_root)` | `(Node)` | Call before adding to scene tree when creating BTPlayer dynamically |
+
+Signals:
+- `updated(status: int)` — emitted after each BT update tick
+- `behavior_tree_finished(status: int)` — **deprecated**, use `updated`
+
+### 3.4 `BTTask` (`BT` → `Resource`)
+
+Base class for all BT tasks. **Do not extend directly** — use `BTAction`, `BTCondition`, `BTDecorator`, or `BTComposite`.
+
+**Virtual methods to override:**
+
+| Method | Signature | Called when |
+|---|---|---|
+| `_setup()` | `-> void` | Once before first tick; initialize state/config here |
+| `_enter()` | `-> void` | When task is entered (status was not RUNNING in previous tick) |
+| `_tick(delta)` | `(float) -> Status` | Each time task is executed; **main logic** |
+| `_exit()` | `-> void` | After `_tick` returns `SUCCESS` or `FAILURE` |
+| `_generate_name()` | `-> String` (const) | Editor display name (requires `@tool`) |
+| `_get_configuration_warnings()` | `-> PackedStringArray` (const) | Editor warnings (requires `@tool`) |
+
+**Properties accessible inside a task:**
+
+| Property | Type | Notes |
+|---|---|---|
+| `agent` | `Node` | The agent node (usually BTPlayer's parent) |
+| `blackboard` | `Blackboard` | The shared data store |
+| `scene_root` | `Node` | Root of the scene the BT is used in; use for `get_node(node_path)` |
+| `status` | `BT.Status` | Last status returned by `_tick` |
+| `elapsed_time` | `float` | Seconds since task was entered; 0 when not RUNNING |
+| `custom_name` | `String` | User-set name override (default `""`) |
+
+**Execution flow for `execute(delta)` (called by BTPlayer, not by user code):**
+1. If `status != RUNNING` → call `_enter()`
+2. Call `_tick(delta)`
+3. If result is `SUCCESS` or `FAILURE` → call `_exit()`
+
+Key non-virtual methods: `abort()`, `add_child(task)`, `add_child_at_index(task, idx)`,
+`remove_child(task)`, `get_child(idx)`, `get_child_count()`, `get_enabled_child_count()`,
+`get_parent()`, `get_root()`, `is_root()`, `is_descendant_of(task)`, `initialize(agent, blackboard, scene_root)`.
+
+### 3.5 `BTAction` and `BTCondition`
+
+- **`BTAction`** (`BTTask`): Leaf tasks that perform work. May span multiple ticks (return `RUNNING`). No children.
+- **`BTCondition`** (`BTTask`): Leaf tasks that check a condition. Typically return `SUCCESS` or `FAILURE` immediately (no `RUNNING`). No children.
+
+Custom task pattern (GDScript):
+
+```gdscript
+@tool
+extends BTAction
+## Moves agent toward a blackboard position.
+
+@export var target_pos_var: StringName = &"target_pos"
+@export var speed: float = 200.0
+
+func _generate_name() -> String:
+    return "MoveToward  %s" % LimboUtility.decorate_var(target_pos_var)
+
+func _setup() -> void:
+    pass  # one-time init
+
+func _enter() -> void:
+    pass  # called when entering from non-RUNNING state
+
+func _tick(delta: float) -> Status:
+    var target: Vector2 = blackboard.get_var(target_pos_var, Vector2.ZERO)
+    var dist := agent.global_position.distance_to(target)
+    if dist < 5.0:
+        return SUCCESS
+    agent.velocity = agent.global_position.direction_to(target) * speed
+    agent.move_and_slide()
+    return RUNNING
+
+func _exit() -> void:
+    pass  # cleanup after SUCCESS or FAILURE
+```
+
+Custom condition pattern:
+
+```gdscript
+@tool
+extends BTCondition
+## Returns SUCCESS if agent is within range of target.
+
+@export var distance_max: float = 150.0
+@export var target_var: StringName = &"target"
+
+var _max_sq: float
+
+func _setup() -> void:
+    _max_sq = distance_max * distance_max
+
+func _tick(_delta: float) -> Status:
+    var target: Node2D = blackboard.get_var(target_var, null)
+    if not is_instance_valid(target):
+        return FAILURE
+    return SUCCESS if agent.global_position.distance_squared_to(
+        target.global_position) <= _max_sq else FAILURE
+```
+
+## 4. Composite tasks
+
+Composites control execution flow and can have multiple children.
+
+| Class | Behaviour |
+|---|---|
+| `BTSequence` | AND logic — runs children left-to-right while they return `SUCCESS`; resumes from last `RUNNING` child next tick |
+| `BTSelector` | OR logic — runs children left-to-right until first `SUCCESS`; resumes from last `RUNNING` child |
+| `BTParallel` | Runs all children each tick (no multithreading); `num_successes_required`/`num_failures_required` control result; optional `repeat` |
+| `BTDynamicSequence` | Like `BTSequence` but re-evaluates preceding children each tick (aborts `RUNNING` child if a preceding child changes result) |
+| `BTDynamicSelector` | Like `BTSelector` but re-evaluates from the start each tick (allows higher-priority fallback to preempt) |
+| `BTRandomSequence` | `BTSequence` with shuffled child order |
+| `BTRandomSelector` | `BTSelector` with shuffled child order |
+| `BTProbabilitySelector` | Weighted random selector using `BTProbability` child weights |
+
+`BTParallel` properties:
+```
+num_failures_required: int  # default 1
+num_successes_required: int  # default 1
+repeat: bool                 # default false — re-execute SUCCESS/FAILURE children each tick
+```
+
+## 5. Decorator tasks
+
+Decorators wrap a single child and modify its behaviour.
+
+| Class | Behaviour / Key properties |
+|---|---|
+| `BTInvert` | Flips `SUCCESS`↔`FAILURE`; passes `RUNNING` through |
+| `BTRepeat` | Repeats child N times (`times: int`) or forever (`forever: bool`); `abort_on_failure: bool` |
+| `BTRepeatUntilSuccess` | Keeps retrying until child returns `SUCCESS` |
+| `BTRepeatUntilFailure` | Keeps retrying until child returns `FAILURE` |
+| `BTAlwaysSucceed` | Returns `SUCCESS` regardless of child result |
+| `BTAlwaysFail` | Returns `FAILURE` regardless of child result |
+| `BTCooldown` | Runs child only if `duration` seconds have passed; `start_cooled`, `trigger_on_failure`, `cooldown_state_var` |
+| `BTTimeLimit` | Aborts child and returns `FAILURE` if `time_limit` exceeded |
+| `BTDelay` | Delays child execution by N seconds |
+| `BTRunLimit` | Restricts child to `run_limit` executions; `count_policy` (COUNT_SUCCESSFUL=0, COUNT_FAILED=1, COUNT_ALL=2) |
+| `BTNewScope` | Creates a new Blackboard scope; `blackboard_plan` property |
+| `BTSubtree` | Loads and runs another `BehaviorTree` resource as a child; creates new scope; `subtree: BehaviorTree` |
+| `BTForEach` | Iterates over a Blackboard array variable |
+| `BTProbability` | Child of `BTProbabilitySelector`; assigns a probability weight |
+
+`BTCooldown` properties:
+```
+duration: float            # default 10.0
+start_cooled: bool         # default false
+trigger_on_failure: bool   # default false
+cooldown_state_var: StringName  # optional BB var to store cooldown state
+process_pause: bool        # default false
+```
+
+`BTRepeat` properties:
+```
+times: int           # default 1
+forever: bool        # default false
+abort_on_failure: bool  # default false
+```
+
+## 6. Built-in leaf tasks (actions and conditions)
+
+### Actions
+| Class | Purpose |
+|---|---|
+| `BTSetVar` | Assigns `value` (BBVariant) to `variable` on blackboard; optional `operation` (LimboUtility.Operation) |
+| `BTCallMethod` | Calls a method on a node |
+| `BTSetAgentProperty` | Sets a property on the agent |
+| `BTPlayAnimation` | Plays an animation |
+| `BTStopAnimation` | Stops an animation |
+| `BTPauseAnimation` | Pauses an animation |
+| `BTAwaitAnimation` | Waits for animation to finish |
+| `BTWait` | Waits N seconds |
+| `BTWaitTicks` | Waits N physics ticks |
+| `BTConsolePrint` | Debug print to console |
+| `BTFail` | Always returns `FAILURE` |
+| `BTEvaluateExpression` | Evaluates a GDScript expression |
+
+### Conditions
+| Class | Purpose |
+|---|---|
+| `BTCheckVar` | Checks `variable` against `value` using `check_type` (LimboUtility.CheckType) |
+| `BTCheckTrigger` | Returns `SUCCESS` and clears a boolean BB variable (one-shot gate) |
+| `BTCheckAgentProperty` | Checks a property on the agent |
+| `BTComment` | No-op; editor annotation; always returns `FAILURE`; `is_enabled()` always false |
+
+`BTCheckVar.check_type` enum values (LimboUtility.CheckType):
+```
+CHECK_EQUAL = 0, CHECK_LESS_THAN = 1, CHECK_LESS_THAN_OR_EQUAL = 2
+CHECK_GREATER_THAN = 3, CHECK_GREATER_THAN_OR_EQUAL = 4, CHECK_NOT_EQUAL = 5
+```
+
+## 7. Blackboard system
+
+### `Blackboard` (`RefCounted`)
+
+Key methods:
+
+```gdscript
+blackboard.get_var(var_name: StringName, default = null, complain: bool = true) -> Variant
+blackboard.set_var(var_name: StringName, value: Variant) -> void
+blackboard.has_var(var_name: StringName) -> bool
+blackboard.erase_var(var_name: StringName) -> void
+blackboard.list_vars() -> StringName[]          # current scope only
+blackboard.get_vars_as_dict() -> Dictionary     # current scope only
+blackboard.clear() -> void                      # current scope only
+blackboard.get_parent() -> Blackboard           # parent scope
+blackboard.set_parent(blackboard: Blackboard)   # assign parent scope
+blackboard.top() -> Blackboard                  # topmost scope in chain
+blackboard.populate_from_dict(dict: Dictionary) -> void
+blackboard.print_state() -> void                # debug: print all scopes
+blackboard.bind_var_to_property(var_name, object, property, create=false)
+blackboard.link_var(var_name, target_blackboard, target_var, create=false)
+blackboard.unbind_var(var_name: StringName)
+```
+
+Usage in tasks:
+
+```gdscript
+# Recommended: suffix exported var names with "_var" for inspector hints
+@export var speed_var: StringName = &"speed"
+@export var target_var: StringName = &"target"
+
+func _tick(delta: float) -> Status:
+    var speed: float = blackboard.get_var(speed_var, 100.0)
+    blackboard.set_var(speed_var, 200.0)
+    if blackboard.has_var(target_var):
+        var obj = blackboard.get_var(target_var)  # no type annotation to avoid freed-instance errors
+        if is_instance_valid(obj):
+            pass
+    return SUCCESS
+```
+
+### `BlackboardPlan` (`Resource`)
+
+Stores the variable schema (types, defaults, hints) for constructing new `Blackboard` instances.
+
+Key methods:
+```gdscript
+blackboard_plan.create_blackboard(prefetch_root: Node, parent_scope: Blackboard = null) -> Blackboard
+blackboard_plan.populate_blackboard(blackboard, overwrite: bool, prefetch_root: Node) -> void
+blackboard_plan.is_derived() -> bool
+blackboard_plan.get_base_plan() -> BlackboardPlan
+blackboard_plan.set_base_plan(plan: BlackboardPlan) -> void
+blackboard_plan.sync_with_base_plan() -> void
+```
+
+Property: `prefetch_nodepath_vars: bool` (default `true`) — automatically resolves `NodePath` variables to node instances on blackboard creation.
+
+### `BBParam` typed parameters
+
+`BBParam` subclasses allow task properties to be either a literal value or a Blackboard variable reference:
+
+```gdscript
+# In an exported property, the inspector shows a BB param editor
+@export var speed: BBFloat
+@export var target_node: BBNode
+
+func _tick(delta: float) -> Status:
+    var s: float = speed.get_value(scene_root, blackboard, 0.0)
+    var node: Node = target_node.get_value(scene_root, blackboard, null)
+    return SUCCESS
+```
+
+Available subtypes: `BBBool`, `BBInt`, `BBFloat`, `BBString`, `BBStringName`, `BBVector2`, `BBVector2i`,
+`BBVector3`, `BBVector3i`, `BBVector4`, `BBVector4i`, `BBColor`, `BBRect2`, `BBRect2i`, `BBArray`,
+`BBDictionary`, `BBNode`, `BBBasis`, `BBTransform2D`, `BBTransform3D`, `BBQuaternion`, `BBPlane`,
+`BBProjection`, `BBVariant`, and packed array variants.
+
+`BBParam.ValueSource` enum:
+```
+SAVED_VALUE = 0    # literal value stored in resource
+BLACKBOARD_VAR = 1 # reference to a named BB variable
+```
+
+Scope rules (new scopes are created automatically):
+- Within `BTNewScope` and `BTSubtree` decorators.
+- For any `LimboState` with non-empty `blackboard_plan`.
+- At root-level `LimboHSM` nodes and each `BTState` child.
+
+## 8. HSM system
+
+### `LimboState` (`Node`)
+
+Base class for states. Extend this for state implementations.
+
+**Virtual methods:**
+
+| Method | When called |
+|---|---|
+| `_setup() -> void` | Once during `hsm.initialize()` |
+| `_enter() -> void` | When state becomes active |
+| `_exit() -> void` | When state becomes inactive (also on `queue_free`; NOT on `free()`) |
+| `_update(delta: float) -> void` | Each update tick while active |
+
+**Properties:**
+
+```gdscript
+agent: Node                  # agent assigned during initialize()
+blackboard: Blackboard       # shared data store for the HSM
+blackboard_plan: BlackboardPlan
+EVENT_FINISHED: StringName   # per-state event name indicating state is done
+```
+
+**Methods:**
+
+```gdscript
+dispatch(event: StringName, cargo: Variant = null) -> bool
+# Propagates event from leaf to root; returns true if consumed.
+
+get_root() -> LimboState     # root state (typically LimboHSM)
+is_active() -> bool
+restart() -> void            # exit and re-enter if active
+
+# Chained builder methods (return self for fluent API):
+named(name: String) -> LimboState
+call_on_enter(callable: Callable) -> LimboState
+call_on_exit(callable: Callable) -> LimboState
+call_on_update(callable: Callable) -> LimboState
+
+# Event handlers:
+add_event_handler(event: StringName, handler: Callable) -> void
+# handler signature: func my_handler(cargo = null) -> bool (return true to consume event)
+remove_event_handler(event: StringName) -> void
+
+# State-wide guard (checked before any transition to this state):
+set_guard(guard_callable: Callable) -> void  # callable -> bool
+clear_guard() -> void
+
+get_cargo() -> Variant   # available only during _enter(); cargo passed to dispatch()
+```
+
+Signals: `entered`, `exited`, `setup`, `updated(delta: float)`.
+
+### `LimboHSM` (`LimboState`)
+
+Hierarchical State Machine node; itself a `LimboState` so it can nest.
+
+**Properties:**
+
+```gdscript
+initial_state: LimboState    # first active state; defaults to first child
+update_mode: LimboHSM.UpdateMode  # IDLE=0, PHYSICS=1, MANUAL=2 (default PHYSICS)
+ANYSTATE: LimboState         # use as from_state for any-state transitions
+```
+
+**Key methods:**
+
+```gdscript
+initialize(agent: Node, parent_scope: Blackboard = null) -> void
+set_active(active: bool) -> void   # activates initial_state when true
+update(delta: float) -> void       # manual tick (when update_mode == MANUAL)
+
+add_transition(from_state, to_state, event: StringName, guard: Callable = Callable()) -> void
+remove_transition(from_state, event: StringName) -> void
+has_transition(from_state, event: StringName) -> bool
+
+get_active_state() -> LimboState
+get_previous_active_state() -> LimboState
+get_leaf_state() -> LimboState
+change_active_state(state: LimboState) -> void  # direct state change (skips event system)
+```
+
+Signal: `active_state_changed(current: LimboState, previous: LimboState)`.
+
+**Complete HSM setup example:**
+
+```gdscript
+# Scene tree: CharacterBody2D -> LimboHSM -> IdleState, MoveState (both LimboState nodes)
+@onready var hsm: LimboHSM = $LimboHSM
+@onready var idle_state: LimboState = $LimboHSM/IdleState
+@onready var move_state: LimboState = $LimboHSM/MoveState
+
+func _ready() -> void:
+    hsm.add_transition(idle_state, move_state, idle_state.EVENT_FINISHED)
+    hsm.add_transition(move_state, idle_state, move_state.EVENT_FINISHED)
+    hsm.initialize(self)
+    hsm.set_active(true)
+```
+
+**Single-file (delegation/fluent) pattern:**
+
+```gdscript
+func _init_state_machine() -> void:
+    var hsm := LimboHSM.new()
+    add_child(hsm)
+
+    var idle_state := LimboState.new().named("Idle") \
+        .call_on_enter(func(): $AnimationPlayer.play("idle")) \
+        .call_on_update(_idle_update)
+    var move_state := LimboState.new().named("Move") \
+        .call_on_enter(func(): $AnimationPlayer.play("walk")) \
+        .call_on_update(_move_update)
+
+    hsm.add_child(idle_state)
+    hsm.add_child(move_state)
+
+    hsm.add_transition(idle_state, move_state, &"movement_started")
+    hsm.add_transition(move_state, idle_state, &"movement_ended")
+    # Any-state transition:
+    hsm.add_transition(hsm.ANYSTATE, idle_state, &"stunned")
+
+    hsm.initialize(self)
+    hsm.set_active(true)
+
+func _idle_update(delta: float) -> void:
+    if not Input.get_vector(&"ui_left", &"ui_right", &"ui_up", &"ui_down").is_zero_approx():
+        hsm.dispatch(&"movement_started")
+```
+
+**State anatomy:**
+
+```gdscript
+extends LimboState
+
+func _setup() -> void:
+    pass  # runs once; agent/blackboard available
+
+func _enter() -> void:
+    pass  # state became active
+
+func _exit() -> void:
+    pass  # state became inactive
+
+func _update(delta: float) -> void:
+    # dispatch an event to trigger a transition:
+    dispatch(EVENT_FINISHED)
+    # or:
+    get_root().dispatch(&"some_event", optional_cargo)
+```
+
+### `BTState` (`LimboState`)
+
+A `LimboState` that runs a `BehaviorTree`. Bridges the HSM and BT systems.
+
+```gdscript
+behavior_tree: BehaviorTree   # the BT resource to execute
+success_event: StringName     # dispatched when BT returns SUCCESS (default: &"success")
+failure_event: StringName     # dispatched when BT returns FAILURE (default: &"failure")
+monitor_performance: bool     # default false
+```
+
+```gdscript
+get_bt_instance() -> BTInstance
+set_scene_root_hint(scene_root: Node) -> void  # call before HSM initialize() for dynamic setup
+```
+
+**HSM + BT integration example:**
+
+```gdscript
+extends CharacterBody2D
+
+func _ready():
+    var hsm := LimboHSM.new()
+    add_child(hsm)
+
+    var bt_state := BTState.new().named("Patrol")
+    bt_state.behavior_tree = preload("res://ai/trees/patrol.tres")
+    bt_state.set_scene_root_hint(self)
+    hsm.add_child(bt_state)
+    hsm.initial_state = bt_state
+
+    hsm.initialize(self)
+    hsm.set_active(true)
+```
+
+## 9. `BTInstance` (`RefCounted`)
+
+Runtime instance of a `BehaviorTree`. Created by `BehaviorTree.instantiate()`.
+
+```gdscript
+get_agent() -> Node
+get_blackboard() -> Blackboard
+get_root_task() -> BTTask
+get_last_status() -> BT.Status
+get_owner_node() -> Node
+get_source_bt_path() -> String
+is_instance_valid() -> bool
+update(delta: float) -> BT.Status   # manually tick the instance
+register_with_debugger() -> void
+monitor_performance: bool
+```
+
+Signals: `updated(status: int)`, `freed`.
+
+## 10. `LimboUtility` (singleton `Object`)
+
+Helper singleton for task display and operations.
+
+```gdscript
+LimboUtility.decorate_var(variable: String) -> String
+LimboUtility.decorate_output_var(variable: String) -> String
+LimboUtility.get_status_name(status: int) -> String
+LimboUtility.get_task_icon(class_or_script_path: String) -> Texture2D
+LimboUtility.perform_check(check: CheckType, a, b) -> bool
+LimboUtility.perform_operation(operation: Operation, a, b) -> Variant
+LimboUtility.get_check_operator_string(check: CheckType) -> String
+LimboUtility.get_operation_string(operation: Operation) -> String
+```
+
+## 11. C# usage
+
+C# is supported via the **module version only** (not GDExtension in v1.7.1). Install the NuGet package from the LimboAI build's `GodotSharp/Tools/nupkgs/` folder:
+
+```shell
+dotnet nuget add source path/to/limboai/nupkgs --name LimboNugetSource
+```
+
+**Key naming differences from GDScript:**
+- Virtual method names use PascalCase with leading underscore: `_Setup()`, `_Enter()`, `_Exit()`, `_Tick()`, `_GenerateName()`, `_Update()`
+- `_Tick` takes `double delta` (not `float`)
+- Status is `Status.Success`, `Status.Failure`, `Status.Running` (not `SUCCESS` etc.)
+- Class names are identical to GDScript: `BTAction`, `BTCondition`, `LimboState`, `LimboHSM`, etc.
+
+**C# custom task template** (verbatim from `doc/source/behavior-trees/custom-tasks.rst`):
+
+```csharp
+using Godot;
+using System;
+
+[Tool]
+public partial class _CLASS_ : _BASE_
+{
+    public override string _GenerateName()
+    {
+        return "_CLASS_";
+    }
+
+    public override void _Setup()
+    {
+    }
+
+    public override void _Enter()
+    {
+    }
+
+    public override void _Exit()
+    {
+    }
+
+    public override Status _Tick(double delta)
+    {
+        return Status.Success;
+    }
+
+    public override string[] _GetConfigurationWarnings()
+    {
+        return Array.Empty<string>();
+    }
+}
+```
+
+**C# HSM state template:**
+
+```csharp
+public partial class IdleState : LimboState
+{
+    public override void _Setup() { }
+
+    public override void _Enter() { }
+
+    public override void _Exit() { }
+
+    public override void _Update(double delta)
+    {
+        Dispatch(EventFinished);
+    }
+}
+```
+
+**Note:** There are no C# example files in the `demo/` folder in v1.7.1 (all demos are GDScript). The official docs confirm GDExtension + C# was unresolved as of this version.
+
+## 12. Custom task location and tooling
+
+- Default search path: `res://ai/tasks/` (configurable in Project Settings → LimboAI with Advanced Settings enabled).
+- Subdirectories under `res://ai/tasks/` become task categories in the editor.
+- Script template: use "Misc → Create script template" in the LimboAI menu.
+- `@tool` annotation required for `_generate_name()` and `_get_configuration_warnings()` to work in editor.
+- `StringName` properties ending with `_var` get a special inspector widget for picking Blackboard variables.
+
+## 13. Gaps / author ourselves
+
+1. **C# examples for Blackboard access** — the docs only show GDScript snippets; the C# equivalents (`blackboard.GetVar<float>(varName, 0f)` equivalent, or `(float)blackboard.GetVar(varName, 0f)`) are not in the official docs. Need to author C# Blackboard examples ourselves.
+
+2. **C# HSM initialization** — the `_init_state_machine()` HSM setup in GDScript uses fluent `.named().call_on_enter()` chaining. The C# equivalents require property assignment (`.Name = "Idle"`) and `Connect(LimboState.SignalName.Entered, ...)` — this is unexampled in the official docs and should be authored.
+
+3. **GDExtension + C# status** — the docs note GDExtension + C# was "unresolved" as of the module docs; the readthedocs C# page explicitly says "I can only confirm success with the module version." The skill should clearly flag that C# requires the module version.
+
+4. **`BBParam` property editor gap in GDExtension** — the inspector-based `BBParam` typed parameter editor (binding a task property to a BB var via UI) is not available in the GDExtension build. No workaround is documented. The skill should note this limitation.
+
+5. **`BTForEach` / `BTEvaluateExpression` / `BTRandomWait`** — these XMLs exist in the repo but lack example code in the official docs. Need to author examples from the XML descriptions alone.
+
+6. **`BTProbabilitySelector` / `BTProbability`** — the weighted random selector works via child `BTProbability` decorators with probability weights, but no example exists in the docs. Need to author.
+
+7. **`BlackboardPlan` mapping (BTState ↔ HSM)** — the `using-blackboard.rst` covers the concept but the programmatic `link_var` approach and its limitations vs. inspector mapping need clearer examples for the skill.
+
+8. **API version drift** — the README compatibility table shows GDExtension minimum was Godot 4.2 in the `.gdextension` file but v1.7.x requires 4.6 at runtime (the file's `compatibility_minimum = "4.2"` is a legacy lower bound; 4.6 is the actual tested minimum per the README matrix). The skill should use 4.6 as the minimum.
+
+9. **`BTPlayer.updated` vs `behavior_tree_finished`** — `behavior_tree_finished` is marked `deprecated` in the XML; always use `updated`.
+
+## Skill-authoring implications
+
+- **Target class hierarchy for coverage:** BehaviorTree (resource) → BTPlayer → BTTask → BTAction/BTCondition → Blackboard; LimboHSM → LimboState → BTState.
+- **C# parity**: All GDScript examples need C# pairs. The C# method-name table (§11) is authoritative.
+- **Cross-refs to plan:** `state-machine` (LimboHSM is a state machine), `event-bus` (dispatch pattern), `ai-navigation` (common BT use case), `gdscript-advanced` (coroutine tasks), `addon-development` (distribution), `csharp-godot` (C# parity gap).
+- **Pattern X candidate:** `BTInstance` low-level API + multi-agent shared Blackboard + `BTSubtree` + `BTProbabilitySelector` examples are good `references/` material (keep core SKILL.md ≤ 16 KB).

--- a/docs/superpowers/notes/2026-06-17-limboai-research.md
+++ b/docs/superpowers/notes/2026-06-17-limboai-research.md
@@ -72,7 +72,7 @@ In task scripts, use the shorthand constants `SUCCESS`, `FAILURE`, `RUNNING` (av
 |---|---|---|
 | `get_root_task()` | `-> BTTask` | Returns root task of the resource |
 | `set_root_task(task)` | `(BTTask)` | Assigns a new root task |
-| `instantiate(agent, blackboard, instance_owner, custom_scene_root=null)` | `-> BTInstance` | Creates a runtime BTInstance; `instance_owner` is typically the BTPlayer/BTState node; `custom_scene_root` overrides `instance_owner.owner` |
+| `instantiate(agent, blackboard, instance_owner, custom_scene_root=null)` | `-> BTInstance` | Creates a runtime BTInstance; `instance_owner` is typically the BTPlayer/BTState node; if `custom_scene_root` is non-null it is used as the scene root, otherwise the scene root defaults to `instance_owner.owner` |
 | `clone()` | `-> BehaviorTree` | Makes a copy of the resource |
 | `copy_other(other)` | `(BehaviorTree)` | Become a copy of another BT |
 
@@ -582,7 +582,7 @@ get_root_task() -> BTTask
 get_last_status() -> BT.Status
 get_owner_node() -> Node
 get_source_bt_path() -> String
-is_instance_valid() -> bool
+is_instance_valid() -> bool                 # instance method (distinct from GDScript's global is_instance_valid())
 update(delta: float) -> BT.Status   # manually tick the instance
 register_with_debugger() -> void
 monitor_performance: bool
@@ -687,7 +687,7 @@ public partial class IdleState : LimboState
 
 ## 13. Gaps / author ourselves
 
-1. **C# examples for Blackboard access** — the docs only show GDScript snippets; the C# equivalents (`blackboard.GetVar<float>(varName, 0f)` equivalent, or `(float)blackboard.GetVar(varName, 0f)`) are not in the official docs. Need to author C# Blackboard examples ourselves.
+1. **C# examples for Blackboard access** — the docs only show GDScript snippets; C# has no generic overload for `GetVar`, so must cast the Variant result: `(float)blackboard.GetVar(varName, 0f)`. The official docs do not show this pattern; need to author C# Blackboard examples ourselves.
 
 2. **C# HSM initialization** — the `_init_state_machine()` HSM setup in GDScript uses fluent `.named().call_on_enter()` chaining. The C# equivalents require property assignment (`.Name = "Idle"`) and `Connect(LimboState.SignalName.Entered, ...)` — this is unexampled in the official docs and should be authored.
 

--- a/docs/superpowers/plans/2026-06-17-v1.10.0-implementation.md
+++ b/docs/superpowers/plans/2026-06-17-v1.10.0-implementation.md
@@ -84,9 +84,9 @@ If the count or warnings differ, stop and reconcile before proceeding.
 **Files:**
 - Create: `docs/superpowers/notes/2026-06-17-limboai-research.md`
 
-- [ ] **Step 1: Gather the LimboAI API surface from official sources**
+- [ ] **Step 1: Gather the LimboAI API surface from the local clone (primary) + docs**
 
-Read the official LimboAI documentation (https://limboai.readthedocs.io/) and the GitHub repo (https://github.com/limbonaut/limboai). Capture **verbatim** into the note:
+Primary source: the local clone at **`D:/Godot/_addon-src/limboai`** — read the verbatim class reference under `doc_classes/*.xml` (e.g. `BTPlayer.xml`, `BTTask.xml`, `LimboHSM.xml`, `LimboState.xml`) and the `.cpp/.h` where an example is needed. **Pin version `v1.7.1`** (latest release as of 2026-06-17 — `git -C D:/Godot/_addon-src/limboai checkout v1.7.1` to read the shipped version, not dev `HEAD`). Cross-check usage with https://limboai.readthedocs.io/. Capture **verbatim** into the note:
 - Current release version + minimum Godot version + license (MIT).
 - Install paths: GDExtension build vs. the engine-module/precompiled editor build.
 - Core classes and their members: `BTPlayer` (`behavior_tree`, `blackboard`, `update_mode`, `active`), `BehaviorTree` resource, `BTTask` virtual methods (`_setup`, `_enter`, `_exit`, `_tick`, `_generate_name`) and return constants (`SUCCESS`, `FAILURE`, `RUNNING`).
@@ -113,9 +113,9 @@ git commit -m "docs(research): capture LimboAI API surface for v1.10.0 limboai s
 **Files:**
 - Create: `docs/superpowers/notes/2026-06-17-beehave-research.md`
 
-- [ ] **Step 1: Gather the Beehave API surface from official sources**
+- [ ] **Step 1: Gather the Beehave API surface from the local clone (primary) + wiki**
 
-Read the Beehave repo + wiki (https://github.com/bitbrain/beehave). Capture verbatim:
+Primary source: the local clone at **`D:/Godot/_addon-src/beehave`** — read the GDScript source under `addons/beehave/` (`blackboard.gd`, `nodes/**/*.gd`, `debug/`, `plugin.cfg`). **Pin version `v2.9.2`** (latest release as of 2026-06-17 — `git -C D:/Godot/_addon-src/beehave checkout v2.9.2` to read the shipped version). Cross-check usage with the repo README + wiki at https://github.com/bitbrain/beehave. Capture verbatim:
 - Current release version + minimum Godot version + license (MIT).
 - Install path (AssetLib / clone into `addons/beehave`), enabling the plugin.
 - Node types: `BeehaveTree` (`actor`, `blackboard`, `tick()`, `enabled`), composites (`SequenceComposite`, `SelectorComposite`, `SimpleParallel`), decorators (`InverterDecorator`, `LimiterDecorator`, `CooldownDecorator`, `FailerDecorator`, `SucceederDecorator`, `TimeLimiterDecorator`), leaves (`ActionLeaf`, `ConditionLeaf`).

--- a/docs/superpowers/plans/2026-06-17-v1.10.0-implementation.md
+++ b/docs/superpowers/plans/2026-06-17-v1.10.0-implementation.md
@@ -1,0 +1,833 @@
+# v1.10.0 Implementation Plan — "Ecosystem & Abilities"
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 3 new skills (`ability-system`, `limboai`, `beehave`), introduce a "Third-Party Addons" category, add Antigravity as a first-class supported platform, wire everything into the cross-reference graph, and ship v1.10.0 (48 → 51 skills).
+
+**Architecture:** This is a documentation/skills repo — there is no app build. Each "test" is `node scripts/validate-skills.mjs` plus reading the file in Godot 4.3+. New skills follow the repo's standard structure (frontmatter, `**Related skills:**` line, numbered GDScript-then-C# sections, implementation checklist, `SKILL.md` ≤ 16 KB with overflow in `references/<topic>.md` per Pattern X). Engine-native content (`ability-system`) is grounded in the local godot-docs clone at `D:\Godot\godot-docs`; addon content (`limboai`, `beehave`) is grounded in each addon's official docs/repo, captured in research notes written first.
+
+**Tech Stack:** Markdown · GDScript & C# (Godot 4.3+) · `node scripts/validate-skills.mjs` · `node scripts/count-tokens.mjs` · `node scripts/bump-version.mjs` · `git` / `gh`
+
+**Spec:** `docs/superpowers/specs/2026-06-17-v1.10.0-design.md`
+
+**Branch:** `feature/v1.10.0` (already created; the spec commit is its first commit).
+
+---
+
+## Global Constraints
+
+- **Godot floor:** core content targets **Godot 4.3+**; features needing newer engines are labeled inline. Addon skills additionally pin the addon version + its minimum Godot version.
+- **Skill structure:** YAML frontmatter with `name:` matching the folder; a `**Related skills:**` line between the H1 and the first `##`; numbered sections; GDScript-then-C# code; an implementation checklist near the end.
+- **Token budget:** every `SKILL.md` must be **< 16384 bytes** (16 KB). `references/<topic>.md` files are unrestricted. Overflow → Pattern X.
+- **C# parity:** every `SKILL.md` section with a ` ```gdscript ` block must also have a ` ```csharp ` block — **except** skills on the `GDSCRIPT_ONLY_BY_DESIGN` allowlist (which will include `beehave` after Task 12). Parity is checked **only in `SKILL.md`**, not in `references/`.
+- **Addon header rule:** every Third-Party Addons skill opens (after the H1 + Related-skills line) with an addon header stating: addon name, pinned version, minimum Godot version, install source/URL, license, implementation language.
+- **Version sync:** `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` must all read `1.10.0` at release.
+
+---
+
+## Validator invariants (read before starting)
+
+The validator (`scripts/validate-skills.mjs`) enforces these; a violation raises a warning or error:
+
+- **frontmatter** (error): `SKILL.md` starts with a YAML `---` block; `name:` matches the folder name; `description:` present.
+- **cross-ref-broken** (error): every skill named on the `**Related skills:**` line and every inline `see <skill> skill` must resolve to an existing `skills/<name>/` folder. → Create the 3 new folders BEFORE wiring them into other skills.
+- **related-skills-line-missing** (warning): a `**Related skills:**` line must sit between the H1 and the first `##`.
+- **csharp-parity-missing** (warning): every `SKILL.md` section with a ` ```gdscript ` block must also contain a ` ```csharp ` block. Sections whose only code is C++/INI/bash do NOT trigger this. Skills in `GDSCRIPT_ONLY_BY_DESIGN` emit `csharp-parity-accepted` instead.
+- **checklist-missing** (warning): an implementation checklist (`- [ ]` items) must appear near the end.
+- **token-budget-exceeded** (warning): `SKILL.md` must be **< 16384 bytes**.
+- **orphan-reference** (warning): every `skills/<name>/references/*.md` must be linked from its parent `SKILL.md`.
+
+**Baseline now:** `Skills validated: 48`, `0 error(s), 10 warning(s).` (the 10 are pre-existing `csharp-parity-accepted` in `gdscript-patterns` + `gdscript-advanced`).
+
+**Target at release:** `Skills validated: 51`, `0 error(s), (10 + N) warning(s)` where **N = number of GDScript code sections in `beehave/SKILL.md`** (all `csharp-parity-accepted`). Record the exact N in Task 12 and again at Task 18. **If any `csharp-parity-missing` (not `-accepted`) appears for a new skill, it is malformed — fix before committing.**
+
+Quick byte-size check:
+```bash
+wc -c skills/<name>/SKILL.md
+```
+
+---
+
+## Phase 0 — Baseline & research notes
+
+### Task 1: Baseline capture (no commit)
+
+**Files:** none modified.
+
+- [ ] **Step 1: Confirm branch + clean tree**
+
+Run:
+```bash
+git status
+git branch --show-current
+git log --oneline -1
+```
+Expected: clean tree; branch `feature/v1.10.0`; HEAD is the v1.10.0 spec commit (`61f14ba` or later).
+
+- [ ] **Step 2: Capture validator baseline**
+
+Run:
+```bash
+node scripts/validate-skills.mjs 2>&1 | tail -3
+```
+Expected:
+```
+Skills validated: 48
+0 error(s), 10 warning(s).
+```
+If the count or warnings differ, stop and reconcile before proceeding.
+
+---
+
+### Task 2: Research note — LimboAI
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-06-17-limboai-research.md`
+
+- [ ] **Step 1: Gather the LimboAI API surface from official sources**
+
+Read the official LimboAI documentation (https://limboai.readthedocs.io/) and the GitHub repo (https://github.com/limbonaut/limboai). Capture **verbatim** into the note:
+- Current release version + minimum Godot version + license (MIT).
+- Install paths: GDExtension build vs. the engine-module/precompiled editor build.
+- Core classes and their members: `BTPlayer` (`behavior_tree`, `blackboard`, `update_mode`, `active`), `BehaviorTree` resource, `BTTask` virtual methods (`_setup`, `_enter`, `_exit`, `_tick`, `_generate_name`) and return constants (`SUCCESS`, `FAILURE`, `RUNNING`).
+- Composite/decorator task names (`BTSequence`, `BTSelector`, `BTParallel`, `BTInvert`, `BTRepeat`, etc.).
+- `Blackboard` access (`get_var`, `set_var`, blackboard plans / `blackboard_plan`).
+- HSM side: `LimboHSM`, `LimboState`, `add_transition`, `dispatch`, event-based transitions.
+- C# usage notes (LimboAI supports C#: class names identical, `_Tick` override casing).
+
+- [ ] **Step 2: Flag doc gaps**
+
+In a "Gaps / author ourselves" section, list any member the official docs don't show a full example for (so the skill author knows what to construct vs. copy). Note any API that changed across recent LimboAI versions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/notes/2026-06-17-limboai-research.md
+git commit -m "docs(research): capture LimboAI API surface for v1.10.0 limboai skill"
+```
+
+---
+
+### Task 3: Research note — Beehave
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-06-17-beehave-research.md`
+
+- [ ] **Step 1: Gather the Beehave API surface from official sources**
+
+Read the Beehave repo + wiki (https://github.com/bitbrain/beehave). Capture verbatim:
+- Current release version + minimum Godot version + license (MIT).
+- Install path (AssetLib / clone into `addons/beehave`), enabling the plugin.
+- Node types: `BeehaveTree` (`actor`, `blackboard`, `tick()`, `enabled`), composites (`SequenceComposite`, `SelectorComposite`, `SimpleParallel`), decorators (`InverterDecorator`, `LimiterDecorator`, `CooldownDecorator`, `FailerDecorator`, `SucceederDecorator`, `TimeLimiterDecorator`), leaves (`ActionLeaf`, `ConditionLeaf`).
+- The leaf contract: override `tick(actor, blackboard) -> int`, returning `SUCCESS`/`FAILURE`/`RUNNING`.
+- `Blackboard` usage (`set_value`/`get_value`).
+- The visual debugger overlay (how to enable in-editor + at runtime).
+- Confirm Beehave is **GDScript-only** (no official C# API) — this drives the allowlist decision.
+
+- [ ] **Step 2: Flag doc gaps** (same as Task 2 Step 2).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/notes/2026-06-17-beehave-research.md
+git commit -m "docs(research): capture Beehave API surface for v1.10.0 beehave skill"
+```
+
+---
+
+### Task 4: Research note — Antigravity platform
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-06-17-antigravity-research.md`
+
+- [ ] **Step 1: Pin the Antigravity skill-loading facts**
+
+From the official Antigravity docs (https://antigravity.google/docs/skills) and the CLI plugins doc, capture verbatim and **resolve the directory discrepancy**:
+- Exact SKILL.md frontmatter fields Antigravity reads (`name`, `description`, optional `tools`).
+- The **workspace** skills directory — resolve `./.agent/skills/<name>/` vs `./.antigravity/skills/<name>/` (sources disagree; trust the official docs, and if possible a live install).
+- The **global** skills directory (e.g. `~/.gemini/antigravity/skills/`).
+- Whether `references/` subfolders are read the same way (they are per community docs — confirm).
+- Whether Antigravity reads `AGENTS.md` / any rules file (the existing `AGENTS.md` re-export may already work).
+- The agent/tool names Antigravity exposes (for the tool-mapping file in Task 13): file read/edit/write, shell/run, search/grep, web, subagent/task equivalents.
+
+- [ ] **Step 2: Record the canonical install path decision**
+
+State a single recommended install path for GodotPrompter users (workspace symlink vs. global clone) with the exact resolved directory, and whether a loader/manifest dir is needed (default: **not** needed — skills load from the skills dir directly).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/notes/2026-06-17-antigravity-research.md
+git commit -m "docs(research): pin Antigravity skill-loading paths + tool names for v1.10.0"
+```
+
+---
+
+## Phase 1 — `ability-system` skill (engine-native)
+
+> Source of truth: the local godot-docs clone at `D:\Godot\godot-docs` (Resource, Timer, signals). All code targets Godot 4.3+. Full GDScript + C# parity. Pattern X from the start.
+
+### Task 5: Create `ability-system/SKILL.md` skeleton + Section 1
+
+**Files:**
+- Create: `skills/ability-system/SKILL.md`
+
+**Interfaces (names later tasks + references rely on — keep identical across all files):**
+- `Ability` (custom `Resource`): exports `ability_name: String`, `cost: float`, `cooldown: float`, `cast_time: float`; method `can_activate(caster) -> bool`; method `activate(caster) -> void`.
+- `AbilityComponent` (`Node`): `grant(ability)`, `try_activate(ability_name)`, signals `ability_activated(ability)`, `ability_failed(ability, reason)`, `cooldown_started(ability, duration)`, `cooldown_finished(ability)`.
+- `StatModifier` (Resource), `StatSet` — defined in `references/stat-modifiers.md`.
+- `GameplayTagContainer` — defined in `references/tags-and-conditions.md`.
+
+- [ ] **Step 1: Create the file with frontmatter + Related-skills line**
+
+```markdown
+---
+name: ability-system
+description: Use when building character abilities — Resource-based abilities with cost/cooldown/cast, buffs/debuffs, stat modifiers, gameplay tags, and HUD binding
+---
+
+# Ability System
+
+Build a data-driven ability system from Godot-native parts: abilities are `Resource`s, an `AbilityComponent` node owns and runs them, and effects/stats/tags compose on top. No third-party addon required.
+
+> **Related skills:** **resource-pattern** for the `Resource` data containers, **component-system** for the component node pattern, **event-bus** for cross-system ability events, **state-machine** for caster states (e.g. casting/stunned), **hud-system** for cooldown UI.
+```
+
+- [ ] **Step 2: Add Section 1 — "Architecture overview"**
+
+Prose + a small bullet list (no code → no parity requirement): Ability = `Resource` (data); `AbilityComponent` = `Node` that holds granted abilities, validates activation, runs cost/cooldown, and emits signals; effects (buffs/debuffs) are applied to a target's stats; stats live in a `StatSet`; gameplay tags gate activation. End with the rule: *"Data in Resources, behavior in the component, communication via signals."* Cross-link the three `references/` files (added in Tasks 6–8) so they are not orphaned.
+
+- [ ] **Step 3: Validate frontmatter + size**
+
+Run:
+```bash
+node scripts/validate-skills.mjs 2>&1 | grep -E "ability-system|error|warning" | head
+wc -c skills/ability-system/SKILL.md
+```
+Expected: a `cross-ref-broken` error is acceptable *only* if it points to the not-yet-linked `references/` files; resolve by ensuring Step 2 links them. No token-budget warning. (Cross-refs to existing skills resolve since `resource-pattern` etc. already exist.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/ability-system/SKILL.md
+git commit -m "feat(ability-system): add skill skeleton + architecture overview"
+```
+
+---
+
+### Task 6: Add Section 2 — "Abilities (cost / cooldown / cast)" with parity
+
+**Files:**
+- Modify: `skills/ability-system/SKILL.md`
+
+- [ ] **Step 1: Write Section 2 with the `Ability` Resource (GDScript)**
+
+```gdscript
+# ability.gd
+class_name Ability
+extends Resource
+
+@export var ability_name: String
+@export var cost: float = 0.0
+@export var cooldown: float = 1.0
+@export var cast_time: float = 0.0
+
+# Override in subclasses or compose via exported effect resources.
+func can_activate(caster: Node) -> bool:
+    return true
+
+func activate(caster: Node) -> void:
+    pass
+```
+
+- [ ] **Step 2: Add the `AbilityComponent` node (GDScript)**
+
+```gdscript
+# ability_component.gd
+class_name AbilityComponent
+extends Node
+
+signal ability_activated(ability: Ability)
+signal ability_failed(ability: Ability, reason: String)
+signal cooldown_started(ability: Ability, duration: float)
+signal cooldown_finished(ability: Ability)
+
+@export var resource_pool: float = 100.0
+
+var _granted: Dictionary = {}        # ability_name -> Ability
+var _cooldowns: Dictionary = {}      # ability_name -> seconds remaining
+
+func grant(ability: Ability) -> void:
+    _granted[ability.ability_name] = ability
+
+func _process(delta: float) -> void:
+    for name in _cooldowns.keys():
+        _cooldowns[name] -= delta
+        if _cooldowns[name] <= 0.0:
+            _cooldowns.erase(name)
+            cooldown_finished.emit(_granted[name])
+
+func try_activate(ability_name: String) -> bool:
+    var ability: Ability = _granted.get(ability_name)
+    if ability == null:
+        return false
+    if _cooldowns.has(ability_name):
+        ability_failed.emit(ability, "on_cooldown")
+        return false
+    if resource_pool < ability.cost:
+        ability_failed.emit(ability, "insufficient_resource")
+        return false
+    if not ability.can_activate(owner):
+        ability_failed.emit(ability, "conditions_unmet")
+        return false
+    resource_pool -= ability.cost
+    ability.activate(owner)
+    _cooldowns[ability_name] = ability.cooldown
+    cooldown_started.emit(ability, ability.cooldown)
+    ability_activated.emit(ability)
+    return true
+```
+
+- [ ] **Step 3: Add the C# parity block**
+
+```csharp
+// Ability.cs
+using Godot;
+
+[GlobalClass]
+public partial class Ability : Resource
+{
+    [Export] public string AbilityName { get; set; } = "";
+    [Export] public float Cost { get; set; } = 0.0f;
+    [Export] public float Cooldown { get; set; } = 1.0f;
+    [Export] public float CastTime { get; set; } = 0.0f;
+
+    public virtual bool CanActivate(Node caster) => true;
+    public virtual void Activate(Node caster) { }
+}
+```
+
+```csharp
+// AbilityComponent.cs
+using Godot;
+using System.Collections.Generic;
+
+public partial class AbilityComponent : Node
+{
+    [Signal] public delegate void AbilityActivatedEventHandler(Ability ability);
+    [Signal] public delegate void AbilityFailedEventHandler(Ability ability, string reason);
+    [Signal] public delegate void CooldownStartedEventHandler(Ability ability, float duration);
+    [Signal] public delegate void CooldownFinishedEventHandler(Ability ability);
+
+    [Export] public float ResourcePool { get; set; } = 100.0f;
+
+    private readonly Dictionary<string, Ability> _granted = new();
+    private readonly Dictionary<string, float> _cooldowns = new();
+
+    public void Grant(Ability ability) => _granted[ability.AbilityName] = ability;
+
+    public override void _Process(double delta)
+    {
+        foreach (var name in new List<string>(_cooldowns.Keys))
+        {
+            _cooldowns[name] -= (float)delta;
+            if (_cooldowns[name] <= 0.0f)
+            {
+                _cooldowns.Remove(name);
+                EmitSignal(SignalName.CooldownFinished, _granted[name]);
+            }
+        }
+    }
+
+    public bool TryActivate(string abilityName)
+    {
+        if (!_granted.TryGetValue(abilityName, out var ability)) return false;
+        if (_cooldowns.ContainsKey(abilityName))
+        {
+            EmitSignal(SignalName.AbilityFailed, ability, "on_cooldown");
+            return false;
+        }
+        if (ResourcePool < ability.Cost)
+        {
+            EmitSignal(SignalName.AbilityFailed, ability, "insufficient_resource");
+            return false;
+        }
+        if (!ability.CanActivate(Owner))
+        {
+            EmitSignal(SignalName.AbilityFailed, ability, "conditions_unmet");
+            return false;
+        }
+        ResourcePool -= ability.Cost;
+        ability.Activate(Owner);
+        _cooldowns[abilityName] = ability.Cooldown;
+        EmitSignal(SignalName.CooldownStarted, ability, ability.Cooldown);
+        EmitSignal(SignalName.AbilityActivated, ability);
+        return true;
+    }
+}
+```
+
+- [ ] **Step 4: Validate (no new parity warning) + size, then commit**
+
+```bash
+node scripts/validate-skills.mjs 2>&1 | tail -3
+wc -c skills/ability-system/SKILL.md
+git add skills/ability-system/SKILL.md
+git commit -m "feat(ability-system): add abilities section (cost/cooldown/cast) with C# parity"
+```
+Expected: warnings still 10; `SKILL.md` < 16384 bytes.
+
+---
+
+### Task 7: Add Section 3 — "Buffs & debuffs (timed effects)" with parity
+
+**Files:**
+- Modify: `skills/ability-system/SKILL.md`
+
+- [ ] **Step 1: Write the `Effect` Resource + applying logic (GDScript)**
+
+```gdscript
+# effect.gd
+class_name Effect
+extends Resource
+
+@export var effect_name: String
+@export var duration: float = 5.0      # seconds; <= 0 means instant
+@export var tick_interval: float = 0.0 # 0 means no periodic tick
+
+func on_apply(target: Node) -> void: pass
+func on_tick(target: Node) -> void: pass
+func on_expire(target: Node) -> void: pass
+```
+
+Then a short `EffectHolder` snippet showing apply → tick (via accumulated delta) → expire, emitting `effect_applied` / `effect_expired` signals. Keep it under ~25 lines; push the full holder to `references/stat-modifiers.md` if the file approaches 16 KB.
+
+- [ ] **Step 2: Add the C# parity block** for `Effect` (`[GlobalClass] partial class Effect : Resource` with `OnApply`/`OnTick`/`OnExpire` virtuals) and the holder.
+
+- [ ] **Step 3: Validate + size + commit**
+
+```bash
+node scripts/validate-skills.mjs 2>&1 | tail -3
+wc -c skills/ability-system/SKILL.md
+git add skills/ability-system/SKILL.md
+git commit -m "feat(ability-system): add buffs/debuffs (timed effects) section with C# parity"
+```
+Expected: 10 warnings; under budget.
+
+---
+
+### Task 8: Add `references/stat-modifiers.md`
+
+**Files:**
+- Create: `skills/ability-system/references/stat-modifiers.md`
+- Modify: `skills/ability-system/SKILL.md` (ensure it links this file)
+
+- [ ] **Step 1: Write the stat-modifier pipeline (GDScript + C#)**
+
+Cover: `StatModifier` Resource (`stat_name`, `operation` enum `ADD`/`MULTIPLY`/`OVERRIDE`, `value`, `source`); `StatSet` that stores base values and a list of modifiers and computes final = (base + sum(ADD)) * product(1+MULTIPLY) with OVERRIDE last; stacking vs. refresh (key by `source`); recalculation trigger + `stat_changed(stat_name, value)` signal; clamping. Provide both GDScript and C# (parity not enforced in references, but include both for quality).
+
+- [ ] **Step 2: Confirm the link exists in `SKILL.md`**
+
+The architecture section (Task 5 Step 2) must contain a markdown link to `references/stat-modifiers.md`. Verify no `orphan-reference` warning:
+```bash
+node scripts/validate-skills.mjs 2>&1 | grep -i orphan
+```
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/ability-system/references/stat-modifiers.md skills/ability-system/SKILL.md
+git commit -m "feat(ability-system): add stat-modifier pipeline reference"
+```
+
+---
+
+### Task 9: Add `references/tags-and-conditions.md`
+
+**Files:**
+- Create: `skills/ability-system/references/tags-and-conditions.md`
+- Modify: `skills/ability-system/SKILL.md` (link it)
+
+- [ ] **Step 1: Write the gameplay-tag/condition system (GDScript + C#)**
+
+Cover: `GameplayTagContainer` (`StringName` tags via a `Dictionary`/`Array`), `has_tag`/`add_tag`/`remove_tag`/`has_any`/`has_all`; gating abilities by required/blocked tags (extend `Ability.can_activate` to check the caster's container); immunities (effect blocked if target has a tag); a worked "stun blocks casting" example. GDScript + C#.
+
+- [ ] **Step 2: Confirm the link + no orphan**, then **Step 3: Commit**
+
+```bash
+node scripts/validate-skills.mjs 2>&1 | grep -i orphan
+git add skills/ability-system/references/tags-and-conditions.md skills/ability-system/SKILL.md
+git commit -m "feat(ability-system): add gameplay-tags & conditions reference"
+```
+
+---
+
+### Task 10: Add `references/ui-binding.md` + implementation checklist
+
+**Files:**
+- Create: `skills/ability-system/references/ui-binding.md`
+- Modify: `skills/ability-system/SKILL.md` (link it + add the checklist)
+
+- [ ] **Step 1: Write the UI binding reference (GDScript + C#)**
+
+Cover: connecting `cooldown_started`/`cooldown_finished`/`ability_activated` to a HUD; a cooldown sweep using a `TextureProgressBar` (radial) driven from `cooldown` remaining; charge pips; buff/debuff icon row driven by `effect_applied`/`effect_expired`. Cross-reference `hud-system` and `godot-ui`.
+
+- [ ] **Step 2: Add the implementation checklist to `SKILL.md`**
+
+Append near the end of `SKILL.md`:
+```markdown
+## Implementation checklist
+
+- [ ] Abilities are `Resource`s; behavior lives in `AbilityComponent`, not in the data.
+- [ ] Activation validates cost, cooldown, and `can_activate()` before spending resources.
+- [ ] Cooldowns tick in `_process`/`_Process` and emit start/finish signals.
+- [ ] Buffs/debuffs apply → tick → expire and emit signals; durations refresh or stack by source.
+- [ ] Stat modifiers recompute deterministically (ADD → MULTIPLY → OVERRIDE) and clamp.
+- [ ] Ability gating uses the gameplay-tag container; immunities block effects.
+- [ ] HUD binds to component signals — no per-frame polling of cooldown state.
+```
+
+- [ ] **Step 3: Validate the whole skill + size + commit**
+
+```bash
+node scripts/validate-skills.mjs 2>&1 | tail -3
+wc -c skills/ability-system/SKILL.md
+git add skills/ability-system/references/ui-binding.md skills/ability-system/SKILL.md
+git commit -m "feat(ability-system): add UI-binding reference + implementation checklist"
+```
+Expected: `Skills validated: 49`; `0 error(s), 10 warning(s).`; `SKILL.md` < 16384 bytes; no `orphan-reference`, no `csharp-parity-missing`.
+
+---
+
+## Phase 2 — `limboai` skill (Third-Party Addon)
+
+> Source of truth: `docs/superpowers/notes/2026-06-17-limboai-research.md`. Full C# parity (LimboAI supports C#). Use Pattern X if `SKILL.md` nears 16 KB (`references/hsm.md` is the natural split).
+
+### Task 11: Create the `limboai` skill
+
+**Files:**
+- Create: `skills/limboai/SKILL.md`
+- Create (if needed for budget): `skills/limboai/references/hsm.md`
+
+- [ ] **Step 1: Frontmatter + Related-skills + addon header**
+
+```markdown
+---
+name: limboai
+description: Use when using the LimboAI addon — behavior trees and hierarchical state machines (C++ GDExtension) with a visual editor, BTTask subclassing, and a blackboard
+---
+
+# LimboAI
+
+> **Related skills:** **ai-navigation** for movement the tasks drive, **state-machine** for core-engine FSM (when you don't need an addon), **beehave** for a lighter GDScript-only BT alternative, **godot-brainstorming** for choosing an AI approach.
+
+> **Addon:** LimboAI · version `<pin from research note>` · Godot `<min>`+ · MIT · source: <github/asset-lib URL> · written in C++ (GDExtension; engine-module build also available). Exposes both GDScript and C#.
+```
+
+- [ ] **Step 2: Section 1 — "When to use LimboAI (which to pick)"**
+
+Prose decision note (no code): core enum/node FSM (`state-machine`) for simple agents; **Beehave** for lightweight GDScript BTs; **LimboAI** when you want BT **and** HSM, a polished visual editor, and C++ performance. No parity requirement (prose).
+
+- [ ] **Step 3: Sections 2–5 from the research note, GDScript + C# each**
+
+Author from `2026-06-17-limboai-research.md`:
+- **Install & setup** (GDExtension vs module) — prose/INI (no parity needed).
+- **Behavior trees** — `BTPlayer` + `BehaviorTree` resource + the visual editor; minimal runnable example. GDScript + C#.
+- **Custom tasks** — subclass `BTTask`, override `_tick` (return `SUCCESS`/`FAILURE`/`RUNNING`), `_setup`, `_enter`, `_exit`. GDScript + C#.
+- **Blackboard** — `get_var`/`set_var`, blackboard plans. GDScript + C#.
+
+- [ ] **Step 4: Section 6 — "Hierarchical state machine (LimboHSM)"**
+
+`LimboHSM` + `LimboState`, `add_transition`, `dispatch(event)`. GDScript + C#. **If `SKILL.md` ≥ ~15 KB, move this section to `references/hsm.md`** and link it from `SKILL.md`.
+
+- [ ] **Step 5: Implementation checklist** (LimboAI-specific: BTPlayer wired, tasks return a status every tick, blackboard keys documented, HSM transitions exhaustive, C# class names match).
+
+- [ ] **Step 6: Validate + size + commit**
+
+```bash
+node scripts/validate-skills.mjs 2>&1 | tail -3
+wc -c skills/limboai/SKILL.md
+git add skills/limboai/
+git commit -m "feat(limboai): add Third-Party Addons skill for LimboAI (BT + HSM)"
+```
+Expected: `Skills validated: 50`; `0 error(s), 10 warning(s).` (no new parity warnings — C# blocks present); under budget; no orphan reference.
+
+---
+
+## Phase 3 — `beehave` skill (Third-Party Addon, GDScript-only)
+
+> Source of truth: `docs/superpowers/notes/2026-06-17-beehave-research.md`. GDScript-only by design → allowlisted in Task 12. Keep `SKILL.md` examples lean (push depth to `references/`, which is not parity-checked) to keep the accepted-warning count small.
+
+### Task 12: Allowlist `beehave` in the validator
+
+**Files:**
+- Modify: `scripts/validate-skills.mjs:22`
+
+- [ ] **Step 1: Add `beehave` to `GDSCRIPT_ONLY_BY_DESIGN`**
+
+Change:
+```javascript
+const GDSCRIPT_ONLY_BY_DESIGN = new Set(['gdscript-patterns', 'gdscript-advanced']);
+```
+to:
+```javascript
+// 'beehave' is a GDScript-only addon (no official C# API), so its sections are accepted, not debt.
+const GDSCRIPT_ONLY_BY_DESIGN = new Set(['gdscript-patterns', 'gdscript-advanced', 'beehave']);
+```
+
+- [ ] **Step 2: Commit (validator change lands before the skill so its warnings classify as `-accepted`)**
+
+```bash
+git add scripts/validate-skills.mjs
+git commit -m "build(validator): allowlist beehave as GDScript-only by design"
+```
+
+---
+
+### Task 13: Create the `beehave` skill
+
+**Files:**
+- Create: `skills/beehave/SKILL.md`
+- Create (optional): `skills/beehave/references/custom-nodes.md`
+
+- [ ] **Step 1: Frontmatter + Related-skills + addon header**
+
+```markdown
+---
+name: beehave
+description: Use when using the Beehave addon — pure-GDScript behavior trees with composites, decorators, leaves, a blackboard, and a visual runtime debugger
+---
+
+# Beehave
+
+> **Related skills:** **ai-navigation** for the movement leaves drive, **state-machine** for core-engine FSM, **limboai** for a heavier C++ BT+HSM alternative, **godot-brainstorming** for choosing an AI approach.
+
+> **Addon:** Beehave · version `<pin from research note>` · Godot `<min>`+ · MIT · source: <github URL> · written in GDScript (no official C# API — this skill is GDScript-only by design).
+```
+
+- [ ] **Step 2: Section 1 — "When to use Beehave (which to pick)"** — prose decision note (mirror the limboai one from the other side).
+
+- [ ] **Step 3: Sections 2–N from the research note (GDScript)**
+
+Keep the **number of GDScript code sections in `SKILL.md` small** (target 3–4) since each becomes a `csharp-parity-accepted` warning. Cover in `SKILL.md`: install/enable; tree composition (`BeehaveTree` + Sequence/Selector + a leaf); the leaf contract (`tick(actor, blackboard)` returning status). Push **custom decorators/conditions + the debugger walkthrough** into `references/custom-nodes.md` (not parity-checked).
+
+- [ ] **Step 4: Implementation checklist** (Beehave-specific).
+
+- [ ] **Step 5: Count the GDScript sections (record N) + validate + commit**
+
+```bash
+node scripts/validate-skills.mjs 2>&1 | tail -5
+wc -c skills/beehave/SKILL.md
+```
+Record N = number of `csharp-parity-accepted` lines mentioning `skills/beehave/SKILL.md`. Expected: `Skills validated: 51`; `0 error(s), (10 + N) warning(s).`; **every** beehave warning is `csharp-parity-accepted` (none `-missing`); under budget; no orphan reference.
+
+```bash
+git add skills/beehave/
+git commit -m "feat(beehave): add Third-Party Addons skill for Beehave (GDScript BT)"
+```
+
+---
+
+## Phase 4 — Antigravity platform support
+
+> Source of truth: `docs/superpowers/notes/2026-06-17-antigravity-research.md`.
+
+### Task 14: Add the Antigravity tool-mapping reference
+
+**Files:**
+- Create: `skills/using-godot-prompter/references/antigravity-tools.md`
+
+- [ ] **Step 1: Mirror the structure of an existing mapping file**
+
+Read `skills/using-godot-prompter/references/gemini-tools.md` for the exact format, then write `antigravity-tools.md` mapping Claude Code tool names → Antigravity equivalents (from the research note): Read/Edit/Write, Bash/run, Grep/Glob/search, WebFetch/WebSearch, Task/subagent, Skill activation. Include how Antigravity discovers GodotPrompter skills (skills dir) and the SKILL.md frontmatter it reads.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add skills/using-godot-prompter/references/antigravity-tools.md
+git commit -m "feat(antigravity): add Antigravity tool-name mapping reference"
+```
+
+---
+
+### Task 15: Wire Antigravity into the bootstrap skill + install docs
+
+**Files:**
+- Modify: `skills/using-godot-prompter/SKILL.md`
+
+- [ ] **Step 1: Add Antigravity to the platform list + tool-mapping table link**
+
+In `using-godot-prompter/SKILL.md`, add Antigravity alongside Cursor/Gemini/Codex/Copilot/OpenCode wherever platforms are enumerated, linking `references/antigravity-tools.md`. Add a short install subsection using the **resolved** skills directory + install method from the research note (Task 4 Step 2).
+
+- [ ] **Step 2: Verify the new reference is linked (no orphan) + validate + commit**
+
+```bash
+node scripts/validate-skills.mjs 2>&1 | grep -i orphan
+node scripts/validate-skills.mjs 2>&1 | tail -3
+git add skills/using-godot-prompter/SKILL.md
+git commit -m "docs(antigravity): wire Antigravity into using-godot-prompter bootstrap + install docs"
+```
+Expected: no orphan; warning count unchanged from Task 13 (10 + N).
+
+---
+
+### Task 16: Antigravity runtime verification
+
+**Files:**
+- Modify: `docs/superpowers/notes/2026-06-17-antigravity-research.md` (append a "Verification result" section)
+
+- [ ] **Step 1: If Antigravity is installed locally, verify discovery + invocation**
+
+Install GodotPrompter skills into the resolved skills directory (symlink per the research note), open Antigravity, and confirm: (a) `using-godot-prompter` is discovered, (b) at least one domain skill (e.g. `player-controller`) loads and its `references/` are reachable. Record pass/fail + the exact path that worked.
+
+- [ ] **Step 2: If Antigravity is NOT available**, record the status as **"format-verified, runtime-pending"** in the note and in the install docs (Task 15), and open a follow-up checkbox for a later release. Do not claim runtime verification that wasn't done.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/notes/2026-06-17-antigravity-research.md
+git commit -m "docs(antigravity): record runtime verification result"
+```
+
+---
+
+## Phase 5 — Wiring, agents, README
+
+### Task 17: Cross-reference + agent wiring + README category
+
+**Files:**
+- Modify: `README.md` (add "Third-Party Addons" category with `limboai` + `beehave`; add `ability-system` under its core category; add Antigravity to the platforms list)
+- Modify: `CLAUDE.md` (Supported Platforms → add Antigravity; skill count 48 → 51; repo-structure skill count note)
+- Modify: `skills/ai-navigation/SKILL.md`, `skills/state-machine/SKILL.md` (add the "which to pick" note + Related-skills links to `limboai`/`beehave`)
+- Modify: `skills/component-system/SKILL.md`, `skills/resource-pattern/SKILL.md`, `skills/event-bus/SKILL.md`, `skills/hud-system/SKILL.md` (Related-skills back-links to `ability-system` where relevant)
+- Modify: `agents/godot-game-architect.md`, `agents/godot-game-dev.md` (reference `ability-system`; mention `limboai`/`beehave` as addon options for AI work)
+
+- [ ] **Step 1: Add reciprocal Related-skills links**
+
+For each new skill, ensure the skills it lists also list it back (the cross-ref heuristic in `docs/superpowers/notes/2026-04-30-cross-ref-heuristic.md`). Add the addon "which to pick" note to `ai-navigation` and `state-machine`.
+
+- [ ] **Step 2: Update README + CLAUDE.md counts and categories**
+
+Add the **Third-Party Addons** section to the README catalog with both addon skills and a one-line "community addons, versions pinned" caveat. Add `ability-system`. Add Antigravity to the platform list in both README and CLAUDE.md. Update the skill count to **51** everywhere it appears (README catalog, CLAUDE.md repo-structure comment `48 → 51`).
+
+- [ ] **Step 3: Update the two agents**
+
+Add `ability-system` to the skill references in `godot-game-architect.md` and `godot-game-dev.md`; add a one-line routing note that LimboAI/Beehave skills exist for projects using those addons.
+
+- [ ] **Step 4: Validate (cross-refs resolve) + commit**
+
+```bash
+node scripts/validate-skills.mjs 2>&1 | tail -3
+git add README.md CLAUDE.md skills/ agents/
+git commit -m "docs(wiring): cross-link new skills, add Third-Party Addons README category + Antigravity platform, update agents & counts"
+```
+Expected: `Skills validated: 51`; `0 error(s), (10 + N) warning(s).`; no `cross-ref-broken`.
+
+---
+
+## Phase 6 — Release mechanics
+
+### Task 18: Pre-release validation sweep
+
+**Files:** none modified.
+
+- [ ] **Step 1: Full validator + token table**
+
+```bash
+node scripts/validate-skills.mjs 2>&1 | tail -5
+node scripts/count-tokens.mjs 2>&1 | tail -20
+```
+Expected: `Skills validated: 51`; `0 error(s), (10 + N) warning(s).`; every `SKILL.md` < 16384 bytes. Confirm the only non-`accepted` warnings are zero. Record the final N.
+
+- [ ] **Step 2: Spot-check the new skills render correctly** — read each new `SKILL.md` end-to-end; confirm addon headers are present, GDScript-then-C# ordering holds (except beehave), and checklists exist.
+
+---
+
+### Task 19: Version bump + CHANGELOG
+
+**Files:**
+- Modify (via script): `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Bump version**
+
+```bash
+node scripts/bump-version.mjs 1.10.0
+```
+**Caution (from prior release):** if `bump-version.mjs` also edits sibling marketplace clones (`D:/AI/skillsmith`, `D:/Godot/godot-prompter-marketplace`), **revert those** — they're stale and the release workflow handles them via `MARKETPLACE_TOKEN`. Verify only this repo's three files changed:
+```bash
+git status
+```
+
+- [ ] **Step 2: Verify the three versions match**
+
+```bash
+grep '"version"' package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json
+```
+Expected: all `1.10.0`.
+
+- [ ] **Step 3: Write the CHANGELOG `## [1.10.0]` section**
+
+Add an entry above `## [1.9.0]` covering: 3 new skills (48 → 51); new Third-Party Addons category (`limboai`, `beehave`); Antigravity as a supported platform; `ability-system`; the validator note (0 errors, 10 + N warnings, N from beehave being GDScript-only-accepted); grounding in addon official docs + research notes. Use the v1.9.0 entry as the format template.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json CHANGELOG.md
+git commit -m "chore(release): bump to 1.10.0 + changelog"
+```
+
+---
+
+### Task 20: Merge, tag, push
+
+**Files:** none modified.
+
+- [ ] **Step 1: Final validate on the branch**
+
+```bash
+node scripts/validate-skills.mjs 2>&1 | tail -3
+```
+Expected: `Skills validated: 51`; `0 error(s), (10 + N) warning(s).`
+
+- [ ] **Step 2: Merge to master (PR or fast-forward, per maintainer preference)**
+
+```bash
+git switch master
+git merge --no-ff feature/v1.10.0 -m "Merge feature/v1.10.0 — Ecosystem & Abilities"
+```
+
+- [ ] **Step 3: Tag + push (triggers `release.yml`)**
+
+```bash
+git tag v1.10.0
+git push origin master --tags
+```
+
+- [ ] **Step 4: Confirm the release workflow**
+
+```bash
+gh run list --workflow=release.yml --limit 1
+```
+Expected: validate ✓, GitHub release published ✓, marketplace bump PRs opened (skillsmith + godot-prompter-marketplace). **Do not hand-commit the sibling marketplace clones** — let the workflow's auto-PRs land (per prior releases).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Third-Party Addons category + convention → Tasks 11, 13, 17 (README category), addon headers in 11/13. ✓
+- `limboai` skill → Task 11. ✓
+- `beehave` skill (GDScript-only, allowlisted) → Tasks 12–13. ✓
+- Antigravity full support (tool map, install, bootstrap/README/CLAUDE.md, verification) → Tasks 4, 14–16, 17. ✓
+- `ability-system` (abilities, buffs/debuffs, stat modifiers, tags/conditions, UI binding, Pattern X) → Tasks 5–10. ✓
+- No new agent; light-touch agent edits → Task 17 Step 3. ✓
+- Cross-ref wiring + reciprocal back-links → Task 17. ✓
+- Grounding + research notes first → Tasks 2–4 (before authoring). ✓
+- Validator clean, warning math (10 + N) → invariants + Tasks 12, 13, 18. ✓
+- Version sync + CHANGELOG + release workflow + sibling-clone caution → Tasks 19–20. ✓
+
+**Placeholder scan:** Addon code is intentionally authored *from the research notes* (Tasks 2–3) rather than fabricated here — the established repo pattern (v1.9.0 cited research notes the same way). Each authoring step names the exact classes/methods/sections to cover and the source note, so there are no vague "implement X" steps. `ability-system` (engine-native, verifiable) has complete inline code. The `<pin ...>` markers in addon headers are explicit "copy the verified value from the research note" instructions, not deferred decisions.
+
+**Type consistency:** `Ability` / `AbilityComponent` member and signal names match across Tasks 5 (interfaces), 6 (impl), 8–10 (references) and the checklist. C# casing (`TryActivate`, `EmitSignal(SignalName.X)`) is consistent.

--- a/docs/superpowers/plans/2026-06-17-v1.10.0-implementation.md
+++ b/docs/superpowers/plans/2026-06-17-v1.10.0-implementation.md
@@ -277,11 +277,11 @@ func try_activate(ability_name: String) -> bool:
     if resource_pool < ability.cost:
         ability_failed.emit(ability, "insufficient_resource")
         return false
-    if not ability.can_activate(owner):
+    if not ability.can_activate(get_parent()):
         ability_failed.emit(ability, "conditions_unmet")
         return false
     resource_pool -= ability.cost
-    ability.activate(owner)
+    ability.activate(get_parent())
     _cooldowns[ability_name] = ability.cooldown
     cooldown_started.emit(ability, ability.cooldown)
     ability_activated.emit(ability)
@@ -352,13 +352,13 @@ public partial class AbilityComponent : Node
             EmitSignal(SignalName.AbilityFailed, ability, "insufficient_resource");
             return false;
         }
-        if (!ability.CanActivate(Owner))
+        if (!ability.CanActivate(GetParent()))
         {
             EmitSignal(SignalName.AbilityFailed, ability, "conditions_unmet");
             return false;
         }
         ResourcePool -= ability.Cost;
-        ability.Activate(Owner);
+        ability.Activate(GetParent());
         _cooldowns[abilityName] = ability.Cooldown;
         EmitSignal(SignalName.CooldownStarted, ability, ability.Cooldown);
         EmitSignal(SignalName.AbilityActivated, ability);

--- a/docs/superpowers/specs/2026-06-17-v1.10.0-design.md
+++ b/docs/superpowers/specs/2026-06-17-v1.10.0-design.md
@@ -1,0 +1,204 @@
+# v1.10.0 Design — "Ecosystem & Abilities"
+
+**Status:** Approved (brainstorming complete 2026-06-17)
+**Author:** Jan Mesarč
+**Predecessor:** v1.9.0 (Native Power & Mobile Shipping — 3 native/mobile skills, shipped 2026-05-29)
+
+## Summary
+
+A feature release with three independent workstreams shipped together:
+
+1. **Open GodotPrompter to the community-addon ecosystem** for the first time, via a new,
+   clearly-scoped **"Third-Party Addons"** skill category seeded with two AI-behavior addons:
+   `limboai` and `beehave` (one skill per addon).
+2. **Add Antigravity (Google's agentic IDE) as a first-class supported platform** — the 6th
+   platform alongside Claude Code, Copilot, Gemini, Codex, Cursor, and OpenCode.
+3. **Ship an `ability-system` skill** — a high-demand gameplay architecture (abilities,
+   buffs/debuffs, stat modifiers, gameplay tags/conditions, UI binding).
+
+The repo grows from **48 → 51 skills**. Godot 4.3+ baseline is unchanged for core content;
+addon skills pin the addon version they target. The validator target is **0 errors**; the
+warning count is expected to rise from **10 → 11**, the new one being a Beehave GDScript-only
+acceptance (see §3) — all 11 intentional `csharp-parity-accepted`. New skills must not introduce
+**token-budget** warnings — every `SKILL.md` stays ≤ 16 KB.
+
+Both multi-release initiatives that defined v1.6.0–v1.8.0 (C# parity, token-budget / Pattern X)
+remain complete, and v1.9.0 shipped clean, so v1.10.0 is a fresh feature direction.
+
+**Version rationale:** All three workstreams are *additive* (new skills, new platform, no
+breaking changes to existing skill APIs or structure), so this is a minor bump to `1.10.0`, not
+a major `2.0.0` — consistent with the feature-driven cadence of v1.5.0→v1.9.0. The first-ever
+third-party category is a notable direction change but does not break existing consumers.
+
+## Goals
+
+1. Establish a durable, clearly-bounded pattern for third-party addon skills that keeps core
+   engine skills pure while making the most-used Godot AI addons first-class.
+2. Reach platform parity for Antigravity, which is format-compatible with GodotPrompter's
+   existing `SKILL.md` + `references/` structure.
+3. Fill the clearest remaining gameplay-architecture gap (ability/buff/stat systems) with one
+   focused, Pattern-X-structured skill.
+4. Keep the cross-reference graph and agent routing coherent: new skills link in, and the
+   existing skills/agents that should mention them do.
+
+## Non-goals (YAGNI)
+
+- Additional third-party addons beyond LimboAI and Beehave (e.g. Phantom Camera, Dialogue
+  Manager, GodotSteam) — the category is seeded, not filled; further addons are future releases.
+- A new dedicated agent (e.g. a `godot-addon-engineer`) — deferred; light-touch edits to
+  existing agents only, consistent with v1.9.0.
+- A general "how to evaluate/choose any addon" meta-skill — deferred.
+- Antigravity-specific *plugin packaging* beyond what parity requires — if a manifest/loader dir
+  proves unnecessary for skills to load, we ship install docs only.
+- Reworking the validator beyond the minimal change needed to accept addon skills (§3).
+
+---
+
+## Workstream 1 — Third-Party Addons category
+
+### Category convention
+
+A new README category, **"Third-Party Addons"**, plus a shared authoring convention every addon
+skill follows. Each addon skill opens (immediately after the H1 + Related-skills line) with an
+**addon header block** stating:
+
+- **Addon name** and a one-line description
+- **Pinned version** the skill targets (and the minimum Godot version it requires)
+- **Install source** (asset library / GitHub URL) and **license**
+- **Language** the addon is written in (affects C# parity expectations)
+
+Content is **grounded in the addon's own official documentation/repository**, the same way core
+skills are grounded in the local godot-docs clone. Research notes for each addon are written
+first (see §6) and cited from the spec/plan.
+
+### Skill 1 — `limboai`
+
+Category: Third-Party Addons. Covers the LimboAI addon (C++ GDExtension; behavior trees + a
+hierarchical state machine, with a visual editor):
+
+1. What LimboAI is, when to reach for it over core FSM / `ai-navigation` (the "which to pick"
+   note), and install (GDExtension build vs. engine module).
+2. Behavior tree basics — `BTPlayer`, `BehaviorTree` resources, the visual editor.
+3. Custom tasks — subclassing `BTTask` (`_tick`, `_setup`, return `SUCCESS`/`FAILURE`/`RUNNING`).
+4. The blackboard — sharing data between tasks; blackboard plans.
+5. The HSM side — `LimboState` / `LimboHSM` and how it relates to the core `state-machine` skill.
+6. GDScript and C# usage (LimboAI exposes both).
+
+### Skill 2 — `beehave`
+
+Category: Third-Party Addons. Covers the Beehave addon (pure GDScript behavior trees with a
+visual runtime debugger):
+
+1. What Beehave is, when to pick it over LimboAI / core FSM (the "which to pick" note), and
+   install (asset library / GitHub).
+2. Tree composition — `BeehaveTree`, composites (Sequence/Selector), decorators, leaves.
+3. Custom actions and conditions — extending `ActionLeaf` / `ConditionLeaf`, return codes.
+4. The blackboard and the visual debugger overlay.
+5. Common patterns (patrol → chase → attack) cross-referenced to `ai-navigation`.
+
+Beehave is **GDScript-only by design**; this skill will be GDScript-only with a short note, and
+is expected to add **one `csharp-parity-accepted` validator warning** (or be allowlisted the same
+way `gdscript-patterns` is). Final warning count target documented in the plan.
+
+### "Which to pick" cross-reference
+
+Both addon skills, plus the core `state-machine` and `ai-navigation` skills, carry a short
+decision note: core enum/node FSM vs. Beehave (lightweight GDScript BT) vs. LimboAI (heavier,
+C++, BT+HSM with editor tooling). Keep it consistent across all four files.
+
+---
+
+## Workstream 2 — Antigravity platform support (full)
+
+**Feasibility (verified 2026-06-17):** Antigravity's Agent Skills use `SKILL.md` with `name` +
+`description` frontmatter — identical to GodotPrompter — and support a `references/` subfolder for
+load-on-demand material, matching Pattern X. Skills load from a workspace skills directory and a
+global one. **GodotPrompter skills therefore run in Antigravity essentially as-is.**
+
+Deliverables for first-class parity:
+
+1. **`skills/using-godot-prompter/references/antigravity-tools.md`** — Claude Code tool names →
+   Antigravity tool-name mapping, mirroring the existing `cursor-tools.md` / `gemini-tools.md` /
+   `codex-tools.md` / `copilot-tools.md` files.
+2. **Install instructions** — pin the actual skills directory by testing (sources disagree:
+   `./.agent/skills/<name>/` vs `./.antigravity/skills/<name>/` for workspace, and
+   `~/.gemini/antigravity/skills/` for global). Document symlink/clone install. Add a loader/
+   manifest dir (mirroring `.opencode` / `.codex`) **only if** skills do not otherwise load.
+3. **Bootstrap wiring** — add Antigravity to the platform list in the `using-godot-prompter`
+   skill, the `README`, and the `CLAUDE.md` "Supported Platforms" section.
+4. **Verification pass** — if Antigravity is installed locally, load GodotPrompter skills and
+   confirm discovery + invocation; record the result. If not available, mark the install path
+   "format-verified, runtime-pending" in the docs and notes.
+
+**Open item to resolve during implementation:** the exact workspace skills directory path
+(`.agent/skills` vs `.antigravity/skills`). The plan must verify this against the official
+Antigravity docs or a live install before publishing install instructions.
+
+---
+
+## Workstream 3 — `ability-system` skill
+
+Category: core (Gameplay / Systems). A focused skill for character ability architecture, built
+**Godot-native** (custom `Resource` + signals + composition, leaning on `component-system`,
+`resource-pattern`, `event-bus`). Broad scope → **Pattern X from the start**: a core `SKILL.md`
+(≤ 16 KB) plus `references/` deep dives. Proposed structure:
+
+Core `SKILL.md`:
+1. Architecture overview — Ability as a `Resource`, an `AbilityComponent` node that owns/runs
+   abilities, signals for activation/cooldown/effect events.
+2. Abilities — resource cost, cooldown, cast/channel, activation flow.
+3. Buffs/debuffs — timed effects applied to a target, tick/expire lifecycle.
+4. Implementation checklist.
+
+`references/`:
+- `stat-modifiers.md` — additive/multiplicative modifier pipeline, stacking vs. refresh,
+  recalculation order, clamping.
+- `tags-and-conditions.md` — gameplay-tag/condition system: ability gating, immunities,
+  requirement checks.
+- `ui-binding.md` — binding ability/cooldown state to a HUD (cooldown sweep, charges, buff
+  icons), cross-referenced to `hud-system` / `godot-ui`.
+
+GDScript **and** C# parity throughout the core file and references (this is engine-native, not
+addon content, so full parity applies).
+
+Skill name confirmed: **`ability-system`** (folder `skills/ability-system/`).
+
+---
+
+## Wiring, agents, and release mechanics
+
+- **No new agent.** Light-touch edits:
+  - Reference `ability-system` from `godot-game-architect` and `godot-game-dev`.
+  - Reference `limboai` / `beehave` from the AI-relevant agents (`godot-game-architect`,
+    `godot-game-dev`) — framed as "if the project uses these addons."
+- **Cross-references:** wire the new skills into `ai-navigation`, `state-machine`,
+  `component-system`, `resource-pattern`, `event-bus`, and `hud-system` where relevant, plus the
+  reciprocal back-links.
+- **Validator:** confirm addon skills pass current checks; make the **minimal** change needed if
+  they're flagged for referencing non-core APIs (e.g. allowlist Beehave as GDScript-only).
+- **Release mechanics:** `node scripts/bump-version.mjs 1.10.0`, CHANGELOG entry, regenerate the
+  token-budget table, validator at 0 errors with the documented warning count, then commit/tag/
+  push and let `release.yml` publish the GitHub release and open the marketplace bump PRs
+  (skillsmith primary + godot-prompter-marketplace legacy) via `MARKETPLACE_TOKEN`.
+
+## Grounding & validation
+
+Same bar as v1.9.0:
+- Every core code example compiles/runs in Godot 4.3+.
+- Addon content verified against each addon's official docs/repo; research notes written first
+  under `docs/superpowers/notes/2026-06-17-{limboai,beehave,antigravity}-research.md` and cited.
+- C# parity for all GDScript except where an addon is GDScript-only (Beehave) — labeled, not
+  silently dropped.
+- `node scripts/validate-skills.mjs` clean (0 errors; warnings only the documented intentional
+  set).
+
+## Success criteria
+
+- 51 skills; `limboai`, `beehave` under a "Third-Party Addons" README category; `ability-system`
+  under a core category — all with their cross-refs and reciprocal back-links present.
+- Antigravity listed as a supported platform in `README`, `CLAUDE.md`, and the
+  `using-godot-prompter` skill, with a working `antigravity-tools.md` mapping and a verified (or
+  explicitly "runtime-pending") install path.
+- Validator: 0 errors; warning count matches the documented target.
+- `package.json` + `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` all at
+  `1.10.0`; CHANGELOG updated; release workflow green.

--- a/docs/superpowers/specs/2026-06-17-v1.10.0-design.md
+++ b/docs/superpowers/specs/2026-06-17-v1.10.0-design.md
@@ -18,9 +18,13 @@ A feature release with three independent workstreams shipped together:
 
 The repo grows from **48 → 51 skills**. Godot 4.3+ baseline is unchanged for core content;
 addon skills pin the addon version they target. The validator target is **0 errors**; the
-warning count is expected to rise from **10 → 11**, the new one being a Beehave GDScript-only
-acceptance (see §3) — all 11 intentional `csharp-parity-accepted`. New skills must not introduce
-**token-budget** warnings — every `SKILL.md` stays ≤ 16 KB.
+warning count rises to **10 + N**, where N = the number of GDScript code sections in
+`beehave/SKILL.md` (Beehave is added to the validator's `GDSCRIPT_ONLY_BY_DESIGN` allowlist, so
+each emits an intentional `csharp-parity-accepted`). Parity is only checked in `SKILL.md`, not
+`references/`, so keeping Beehave examples lean in the core file keeps N small (expected ~3–5);
+the exact final number is recorded in the plan. `limboai` ships full C# parity (LimboAI supports
+C#) and adds no warnings. New skills must not introduce **token-budget** warnings — every
+`SKILL.md` stays ≤ 16 KB.
 
 Both multi-release initiatives that defined v1.6.0–v1.8.0 (C# parity, token-budget / Pattern X)
 remain complete, and v1.9.0 shipped clean, so v1.10.0 is a fresh feature direction.
@@ -97,8 +101,10 @@ visual runtime debugger):
 5. Common patterns (patrol → chase → attack) cross-referenced to `ai-navigation`.
 
 Beehave is **GDScript-only by design**; this skill will be GDScript-only with a short note, and
-is expected to add **one `csharp-parity-accepted` validator warning** (or be allowlisted the same
-way `gdscript-patterns` is). Final warning count target documented in the plan.
+will be added to the validator's `GDSCRIPT_ONLY_BY_DESIGN` allowlist (the same mechanism as
+`gdscript-patterns`). Each GDScript code section in `beehave/SKILL.md` then emits an intentional
+`csharp-parity-accepted` warning; keeping examples lean (pushing depth to `references/`, which is
+not parity-checked) keeps that count small. Final warning count recorded in the plan.
 
 ### "Which to pick" cross-reference
 

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -4,7 +4,7 @@ This page documents the token cost of every skill and agent in the repository, s
 
 ## What this is
 
-GodotPrompter ships **48 skills** and **9 agents** as Markdown files. When an AI coding assistant (Claude Code, Copilot, Gemini, Cursor, etc.) loads a skill, every byte of the skill's `SKILL.md` enters the model's context. Loading 3-4 skills is normal for a single feature task — without the budget rule that's 20-30k tokens before the user prompt even starts; with it, restructured skills load 50-60% lighter.
+GodotPrompter ships **51 skills** and **9 agents** as Markdown files. When an AI coding assistant (Claude Code, Copilot, Gemini, Cursor, etc.) loads a skill, every byte of the skill's `SKILL.md` enters the model's context. Loading 3-4 skills is normal for a single feature task — without the budget rule that's 20-30k tokens before the user prompt even starts; with it, restructured skills load 50-60% lighter.
 
 To keep skills loadable in combination, v1.7.0 introduced a **16 KB budget** for `SKILL.md` files. Skills that exceed the budget are progressively restructured using the **Pattern X** approach — core SKILL.md (canonical recipe + distinguishing choices + anti-patterns) plus `references/<topic>.md` files that load only when an agent explicitly opens them.
 
@@ -27,216 +27,225 @@ Columns:
 <!-- BEGIN-TOKEN-TABLE -->
 | Kind | Name | Bytes | KB | Est. tokens | Claude | GPT | Status |
 |---|---|---:|---:|---:|---:|---:|---|
-| skill | animation-system | 16364 | 16.0 | 4091 | 4207 | 3785 | ✓ under budget |
-| skill | 3d-essentials | 16307 | 15.9 | 4077 | 4083 | 3706 | ✓ under budget |
-| skill | physics-system | 16300 | 15.9 | 4075 | 4532 | 4146 | ✓ under budget |
-| skill | ai-navigation | 16007 | 15.6 | 4002 | 4344 | 3905 | ✓ under budget |
-| skill | multiplayer-basics | 15997 | 15.6 | 3999 | 4340 | 3737 | ✓ under budget |
-| skill | event-bus | 15865 | 15.5 | 3966 | 4129 | 3529 | ✓ under budget |
-| skill | shader-basics | 15826 | 15.5 | 3957 | 4090 | 3642 | ✓ under budget |
-| skill | localization | 15649 | 15.3 | 3912 | 4308 | 3834 | ✓ under budget |
-| skill | assets-pipeline | 15592 | 15.2 | 3898 | 3828 | 3480 | ✓ under budget |
-| skill | xr-development | 15344 | 15.0 | 3836 | 4047 | 3705 | ✓ under budget |
-| skill | gdscript-patterns | 15141 | 14.8 | 3785 | 4090 | 3710 | ✓ under budget |
-| skill | input-handling | 14955 | 14.6 | 3739 | 3906 | 3419 | ✓ under budget |
-| skill | godot-code-review | 14602 | 14.3 | 3651 | 4028 | 3566 | ✓ under budget |
-| skill | particles-vfx | 14564 | 14.2 | 3641 | 4032 | 3668 | ✓ under budget |
-| skill | godot-brainstorming | 14097 | 13.8 | 3524 | 3718 | 3497 | ✓ under budget |
-| skill | godot-ui | 14061 | 13.7 | 3515 | 3992 | 3589 | ✓ under budget |
-| skill | state-machine | 14036 | 13.7 | 3509 | 3783 | 3255 | ✓ under budget |
-| skill | export-pipeline | 14005 | 13.7 | 3501 | 3749 | 3291 | ✓ under budget |
-| skill | csharp-godot | 13944 | 13.6 | 3486 | 3952 | 3556 | ✓ under budget |
-| skill | component-system | 13935 | 13.6 | 3484 | 3545 | 3117 | ✓ under budget |
-| skill | player-controller | 13918 | 13.6 | 3480 | 3745 | 3433 | ✓ under budget |
-| skill | audio-system | 13901 | 13.6 | 3475 | 3718 | 3327 | ✓ under budget |
-| skill | inventory-system | 13872 | 13.5 | 3468 | 3313 | 2971 | ✓ under budget |
-| skill | tween-animation | 13528 | 13.2 | 3382 | 3941 | 3382 | ✓ under budget |
-| skill | addon-development | 13447 | 13.1 | 3362 | 3568 | 3158 | ✓ under budget |
-| reference | save-load/json-saves.md | 12833 | 12.5 | 3208 | 3197 | 2704 | — |
-| skill | godot-project-setup | 12817 | 12.5 | 3204 | 3724 | 3189 | ✓ under budget |
-| skill | math-essentials | 12716 | 12.4 | 3179 | 3568 | 3144 | ✓ under budget |
-| skill | resource-pattern | 12464 | 12.2 | 3116 | 3357 | 3032 | ✓ under budget |
-| skill | godot-debugging | 12259 | 12.0 | 3065 | 3140 | 2835 | ✓ under budget |
-| skill | godot-optimization | 11865 | 11.6 | 2966 | 3097 | 2801 | ✓ under budget |
-| skill | dedicated-server | 11715 | 11.4 | 2929 | 3000 | 2669 | ✓ under budget |
-| skill | hud-system | 11477 | 11.2 | 2869 | 3138 | 2730 | ✓ under budget |
-| skill | dependency-injection | 11334 | 11.1 | 2834 | 2860 | 2522 | ✓ under budget |
-| skill | camera-system | 11038 | 10.8 | 2760 | 3182 | 2911 | ✓ under budget |
-| skill | dialogue-system | 10898 | 10.6 | 2725 | 2552 | 2230 | ✓ under budget |
-| skill | multiplayer-sync | 10659 | 10.4 | 2665 | 2719 | 2516 | ✓ under budget |
-| skill | scene-organization | 10447 | 10.2 | 2612 | 2717 | 2433 | ✓ under budget |
-| reference | godot-optimization/memory-management.md | 10420 | 10.2 | 2605 | 2795 | 2494 | — |
-| skill | multithreading | 10367 | 10.1 | 2592 | 2809 | 2399 | ✓ under budget |
-| skill | gdscript-advanced | 10075 | 9.8 | 2519 | 2766 | 2463 | ✓ under budget |
-| skill | using-godot-prompter | 9924 | 9.7 | 2481 | 2596 | 2332 | ✓ under budget |
-| skill | csharp-signals | 9651 | 9.4 | 2413 | 2447 | 2225 | ✓ under budget |
-| skill | godot-testing | 9564 | 9.3 | 2391 | 2346 | 2037 | ✓ under budget |
-| reference | dedicated-server/lobby-management.md | 9121 | 8.9 | 2280 | 2387 | 2061 | — |
-| skill | gdextension | 8949 | 8.7 | 2237 | 2599 | 2201 | ✓ under budget |
-| skill | responsive-ui | 8912 | 8.7 | 2228 | 2393 | 2161 | ✓ under budget |
-| skill | 2d-essentials | 8814 | 8.6 | 2204 | 2412 | 2227 | ✓ under budget |
-| reference | addon-development/inspector-plugins.md | 8649 | 8.4 | 2162 | 2237 | 1963 | — |
-| reference | ai-navigation/chase-attack.md | 8531 | 8.3 | 2133 | 2189 | 1934 | — |
-| reference | dialogue-system/ui-presentation.md | 8498 | 8.3 | 2125 | 1943 | 1703 | — |
-| skill | mobile-development | 8043 | 7.9 | 2011 | 2205 | 1942 | ✓ under budget |
-| reference | godot-optimization/cpu-bottlenecks.md | 7642 | 7.5 | 1911 | 2116 | 1872 | — |
-| reference | godot-ui/ui-patterns.md | 7611 | 7.4 | 1903 | 2091 | 1766 | — |
-| reference | dialogue-system/dialogue-manager.md | 7540 | 7.4 | 1885 | 1944 | 1657 | — |
-| reference | procedural-generation/wave-function-collapse.md | 7334 | 7.2 | 1834 | 1954 | 1780 | — |
-| reference | inventory-system/ui-binding.md | 6873 | 6.7 | 1718 | 1821 | 1585 | — |
-| reference | godot-optimization/draw-calls.md | 6785 | 6.6 | 1696 | 1863 | 1635 | — |
-| reference | addon-development/gizmos-deep-dive.md | 6717 | 6.6 | 1679 | 2132 | 1892 | — |
-| reference | animation-system/ik-recipes.md | 6608 | 6.5 | 1652 | 2082 | 1888 | — |
-| reference | procedural-generation/bsp-dungeons.md | 6542 | 6.4 | 1636 | 2079 | 1779 | — |
-| reference | camera-system/camera3d-patterns.md | 6471 | 6.3 | 1618 | 1801 | 1636 | — |
-| reference | hud-system/damage-numbers.md | 6451 | 6.3 | 1613 | 1871 | 1658 | — |
-| reference | dedicated-server/match-flow.md | 6433 | 6.3 | 1608 | 1602 | 1404 | — |
-| reference | event-bus/testing.md | 6372 | 6.2 | 1593 | 1797 | 1520 | — |
-| reference | 3d-essentials/environment-and-post.md | 6266 | 6.1 | 1567 | 1647 | 1513 | — |
-| reference | ai-navigation/behavior-trees.md | 6266 | 6.1 | 1567 | 1774 | 1528 | — |
-| reference | ai-navigation/steering-behaviors.md | 6086 | 5.9 | 1522 | 1304 | 1166 | — |
-| reference | godot-testing/tdd-workflow.md | 5945 | 5.8 | 1486 | 1702 | 1476 | — |
-| agent | godot-tools-engineer | 5931 | 5.8 | 1483 | 1606 | 1467 | — |
-| reference | physics-system/rigidbody-recipes.md | 5891 | 5.8 | 1473 | 1719 | 1512 | — |
-| reference | tween-animation/common-recipes.md | 5726 | 5.6 | 1432 | 2013 | 1657 | — |
-| agent | godot-csharp-engineer | 5726 | 5.6 | 1432 | 1587 | 1454 | — |
-| reference | inventory-system/serialization.md | 5705 | 5.6 | 1426 | 1290 | 1114 | — |
-| reference | multiplayer-sync/client-prediction.md | 5614 | 5.5 | 1404 | 1478 | 1332 | — |
-| reference | multiplayer-sync/lag-compensation.md | 5517 | 5.4 | 1379 | 1509 | 1332 | — |
-| reference | godot-debugging/signal-tracing.md | 5452 | 5.3 | 1363 | 1482 | 1232 | — |
-| reference | hud-system/interaction-prompts.md | 5451 | 5.3 | 1363 | 1482 | 1313 | — |
-| reference | input-handling/action-rebinding.md | 5369 | 5.2 | 1342 | 1415 | 1235 | — |
-| reference | audio-system/interactive-music.md | 5333 | 5.2 | 1333 | 1562 | 1327 | — |
-| agent | godot-animator | 5266 | 5.1 | 1317 | 1340 | 1246 | — |
-| reference | state-machine/hierarchical-and-parallel.md | 5241 | 5.1 | 1310 | 1401 | 1195 | — |
-| agent | godot-ui-designer | 5088 | 5.0 | 1272 | 1326 | 1217 | — |
-| reference | dedicated-server/server-config.md | 5002 | 4.9 | 1251 | 1444 | 1284 | — |
-| reference | csharp-signals/custom-signal-patterns.md | 4993 | 4.9 | 1248 | 1260 | 1126 | — |
-| skill | procedural-generation | 4975 | 4.9 | 1244 | 1357 | 1224 | ✓ under budget |
-| reference | 2d-essentials/tilemap.md | 4969 | 4.9 | 1242 | 1353 | 1210 | — |
-| reference | dependency-injection/service-locator.md | 4914 | 4.8 | 1229 | 1237 | 1079 | — |
-| reference | camera-system/transitions.md | 4886 | 4.8 | 1222 | 1365 | 1146 | — |
-| reference | dialogue-system/branching-and-conditions.md | 4871 | 4.8 | 1218 | 1394 | 1178 | — |
-| reference | particles-vfx/vfx-recipes.md | 4803 | 4.7 | 1201 | 1615 | 1544 | — |
-| reference | responsive-ui/mobile.md | 4787 | 4.7 | 1197 | 1348 | 1100 | — |
-| reference | godot-optimization/physics-tuning.md | 4754 | 4.6 | 1189 | 1369 | 1239 | — |
-| skill | save-load | 4742 | 4.6 | 1186 | 1137 | 1006 | ✓ under budget |
-| agent | godot-performance-profiler | 4672 | 4.6 | 1168 | 1154 | 1105 | — |
-| reference | procedural-generation/cellular-automata.md | 4655 | 4.5 | 1164 | 1340 | 1289 | — |
-| reference | godot-brainstorming/example-chest.md | 4578 | 4.5 | 1145 | 1323 | 1179 | — |
-| reference | input-handling/mouse.md | 4510 | 4.4 | 1128 | 1225 | 1033 | — |
-| reference | dialogue-system/external-formats.md | 4491 | 4.4 | 1123 | 1198 | 1030 | — |
-| agent | godot-game-dev | 4478 | 4.4 | 1120 | 1244 | 1131 | — |
-| reference | audio-system/sfx-pooling.md | 4469 | 4.4 | 1117 | 1347 | 1230 | — |
-| reference | multiplayer-sync/bandwidth-optimization.md | 4431 | 4.3 | 1108 | 1228 | 1137 | — |
-| reference | godot-testing/testing-patterns.md | 4377 | 4.3 | 1094 | 1345 | 1142 | — |
-| reference | godot-debugging/performance-debugging.md | 4315 | 4.2 | 1079 | 1202 | 1038 | — |
-| agent | godot-shader-author | 4264 | 4.2 | 1066 | 1124 | 1038 | — |
-| reference | player-controller/common-movement-recipes.md | 4257 | 4.2 | 1064 | 1174 | 1049 | — |
-| reference | godot-debugging/systematic-method.md | 4245 | 4.1 | 1061 | 1187 | 1064 | — |
-| reference | shader-basics/compositor-effects.md | 4228 | 4.1 | 1057 | 1109 | 959 | — |
-| reference | input-handling/gamepad.md | 4218 | 4.1 | 1055 | 1226 | 1084 | — |
-| agent | godot-game-architect | 4216 | 4.1 | 1054 | 1066 | 979 | — |
-| reference | inventory-system/equipment.md | 4191 | 4.1 | 1048 | 1098 | 973 | — |
-| reference | multiplayer-basics/player-join-flow.md | 4188 | 4.1 | 1047 | 1237 | 1036 | — |
-| reference | hud-system/notifications.md | 4179 | 4.1 | 1045 | 1197 | 1021 | — |
-| reference | save-load/save-architecture.md | 4160 | 4.1 | 1040 | 1138 | 979 | — |
-| reference | multithreading/pitfalls.md | 4143 | 4.0 | 1036 | 1057 | 955 | — |
-| reference | 2d-essentials/2d-particles.md | 4083 | 4.0 | 1021 | 1159 | 1068 | — |
-| reference | dedicated-server/deployment.md | 4071 | 4.0 | 1018 | 1237 | 1048 | — |
-| reference | 2d-essentials/lights-and-shadows.md | 4006 | 3.9 | 1002 | 1171 | 1068 | — |
-| reference | 3d-essentials/materials-and-lighting-recipes.md | 3959 | 3.9 | 990 | 1266 | 1099 | — |
-| reference | procedural-generation/noise-generation.md | 3958 | 3.9 | 990 | 1250 | 1161 | — |
-| reference | mobile-development/plugins.md | 3879 | 3.8 | 970 | 1093 | 962 | — |
-| reference | shader-basics/2d-shader-recipes.md | 3707 | 3.6 | 927 | 1292 | 1136 | — |
-| reference | audio-system/music-manager.md | 3649 | 3.6 | 912 | 1082 | 920 | — |
-| agent | godot-code-reviewer | 3642 | 3.6 | 911 | 1046 | 933 | — |
-| reference | audio-system/audio-settings.md | 3635 | 3.5 | 909 | 1054 | 919 | — |
-| reference | godot-ui/theme-system.md | 3601 | 3.5 | 900 | 1134 | 981 | — |
-| reference | dependency-injection/testing-with-di.md | 3558 | 3.5 | 890 | 1016 | 894 | — |
-| reference | hud-system/minimap.md | 3528 | 3.4 | 882 | 1029 | 929 | — |
-| reference | camera-system/camera-zones.md | 3506 | 3.4 | 877 | 1062 | 919 | — |
-| reference | physics-system/raycasting-recipes.md | 3493 | 3.4 | 873 | 980 | 884 | — |
-| reference | resource-pattern/configuration-pattern.md | 3481 | 3.4 | 870 | 1043 | 974 | — |
-| reference | save-load/configfile.md | 3445 | 3.4 | 861 | 1023 | 845 | — |
-| reference | 3d-essentials/lod-and-culling.md | 3404 | 3.3 | 851 | 1076 | 938 | — |
-| reference | physics-system/softbody-recipes.md | 3376 | 3.3 | 844 | 912 | 822 | — |
-| reference | resource-pattern/collections.md | 3375 | 3.3 | 844 | 892 | 763 | — |
-| reference | particles-vfx/attractors-and-collision.md | 3346 | 3.3 | 837 | 985 | 903 | — |
-| reference | xr-development/controllers-and-input.md | 3293 | 3.2 | 823 | 932 | 821 | — |
-| reference | camera-system/split-screen.md | 3253 | 3.2 | 813 | 929 | 812 | — |
-| reference | godot-debugging/scene-tree-debugging.md | 3218 | 3.1 | 805 | 901 | 784 | — |
-| reference | multiplayer-basics/disconnect-handling.md | 3212 | 3.1 | 803 | 887 | 738 | — |
-| reference | animation-system/bone-constraints.md | 3207 | 3.1 | 802 | 910 | 819 | — |
-| reference | xr-development/grabbing-objects.md | 3182 | 3.1 | 796 | 856 | 763 | — |
-| reference | multiplayer-sync/interpolation.md | 3169 | 3.1 | 792 | 834 | 758 | — |
-| reference | multiplayer-basics/spawning-networked-objects.md | 3144 | 3.1 | 786 | 910 | 755 | — |
-| reference | 2d-essentials/custom-drawing.md | 3119 | 3.0 | 780 | 971 | 868 | — |
-| reference | mobile-development/iap-and-ads.md | 3050 | 3.0 | 763 | 825 | 686 | — |
-| reference | export-pipeline/distribution-itch-steam.md | 3026 | 3.0 | 757 | 890 | 777 | — |
-| reference | ai-navigation/patrol-patterns.md | 2992 | 2.9 | 748 | 877 | 754 | — |
-| reference | responsive-ui/adaptive-layouts.md | 2888 | 2.8 | 722 | 828 | 724 | — |
-| reference | 3d-essentials/fog-recipes.md | 2875 | 2.8 | 719 | 1036 | 935 | — |
-| reference | shader-basics/stencil-buffer.md | 2856 | 2.8 | 714 | 823 | 728 | — |
-| reference | godot-ui/focus-and-navigation.md | 2845 | 2.8 | 711 | 829 | 683 | — |
-| reference | math-essentials/random-numbers.md | 2792 | 2.7 | 698 | 881 | 826 | — |
-| reference | 2d-essentials/parallax.md | 2776 | 2.7 | 694 | 851 | 776 | — |
-| reference | gdscript-patterns/super-in-virtual-methods.md | 2771 | 2.7 | 693 | 748 | 670 | — |
-| reference | shader-basics/post-processing.md | 2735 | 2.7 | 684 | 903 | 835 | — |
-| reference | math-essentials/game-math-recipes.md | 2727 | 2.7 | 682 | 849 | 707 | — |
-| reference | dependency-injection/autoloads.md | 2649 | 2.6 | 662 | 707 | 630 | — |
-| reference | responsive-ui/pixel-art-setup.md | 2644 | 2.6 | 661 | 758 | 634 | — |
-| reference | dependency-injection/export-injection.md | 2593 | 2.5 | 648 | 687 | 613 | — |
-| reference | gdscript-patterns/common-idioms.md | 2586 | 2.5 | 647 | 760 | 669 | — |
-| reference | godot-testing/running-tests.md | 2577 | 2.5 | 644 | 810 | 775 | — |
-| reference | csharp-signals/disconnecting.md | 2560 | 2.5 | 640 | 651 | 591 | — |
-| reference | csharp-signals/awaiting-signals.md | 2550 | 2.5 | 638 | 698 | 586 | — |
-| reference | 3d-essentials/global-illumination.md | 2545 | 2.5 | 636 | 756 | 679 | — |
-| reference | physics-system/ragdoll-recipes.md | 2528 | 2.5 | 632 | 732 | 647 | — |
-| reference | xr-development/hand-tracking.md | 2519 | 2.5 | 630 | 671 | 583 | — |
-| reference | resource-pattern/editor-integration.md | 2503 | 2.4 | 626 | 763 | 702 | — |
-| reference | gdscript-advanced/profiler-recipes.md | 2497 | 2.4 | 624 | 828 | 703 | — |
-| reference | godot-ui/signals.md | 2472 | 2.4 | 618 | 762 | 661 | — |
-| reference | export-pipeline/ci-cd-github-actions.md | 2460 | 2.4 | 615 | 675 | 628 | — |
-| reference | 3d-essentials/decals.md | 2459 | 2.4 | 615 | 763 | 679 | — |
-| reference | gdscript-patterns/abstract-classes.md | 2422 | 2.4 | 606 | 634 | 564 | — |
-| reference | dependency-injection/scene-injection.md | 2402 | 2.3 | 601 | 615 | 563 | — |
-| reference | dialogue-system/variable-interpolation.md | 2386 | 2.3 | 597 | 643 | 547 | — |
-| reference | save-load/version-migration.md | 2368 | 2.3 | 592 | 604 | 568 | — |
-| reference | gdscript-advanced/tool-script-recipes.md | 2350 | 2.3 | 588 | 686 | 607 | — |
-| reference | particles-vfx/subemitters.md | 2319 | 2.3 | 580 | 614 | 532 | — |
-| reference | physics-system/area-recipes.md | 2233 | 2.2 | 558 | 670 | 568 | — |
-| reference | animation-system/sprite-animation.md | 2195 | 2.1 | 549 | 573 | 509 | — |
-| reference | resource-pattern/sharing-vs-unique.md | 2122 | 2.1 | 531 | 540 | 492 | — |
-| reference | gdextension/debugging-native.md | 2096 | 2.0 | 524 | 546 | 486 | — |
-| reference | addon-development/dock-panels.md | 2086 | 2.0 | 522 | 663 | 560 | — |
-| reference | gdscript-advanced/metaprogramming-recipes.md | 2081 | 2.0 | 520 | 628 | 521 | — |
-| reference | particles-vfx/trails.md | 2007 | 2.0 | 502 | 539 | 471 | — |
-| reference | animation-system/skeleton-modifiers.md | 2000 | 2.0 | 500 | 604 | 535 | — |
-| reference | xr-development/xr-ui.md | 1985 | 1.9 | 496 | 566 | 480 | — |
-| reference | gdextension/rust-gdext.md | 1971 | 1.9 | 493 | 637 | 550 | — |
-| reference | math-essentials/curves-and-paths.md | 1895 | 1.9 | 474 | 599 | 533 | — |
-| reference | animation-system/common-recipes.md | 1892 | 1.8 | 473 | 582 | 510 | — |
-| reference | resource-pattern/saving-resources.md | 1882 | 1.8 | 471 | 522 | 460 | — |
-| reference | physics-system/staticbody-recipes.md | 1879 | 1.8 | 470 | 549 | 484 | — |
-| reference | responsive-ui/dpi-scaling.md | 1845 | 1.8 | 461 | 584 | 520 | — |
-| reference | gdscript-patterns/export-annotations.md | 1821 | 1.8 | 455 | 588 | 540 | — |
-| reference | gdscript-patterns/variadic-functions.md | 1805 | 1.8 | 451 | 514 | 477 | — |
-| reference | particles-vfx/flipbook-animation.md | 1781 | 1.7 | 445 | 499 | 469 | — |
-| reference | csharp-signals/connecting-gdscript-signals.md | 1770 | 1.7 | 443 | 481 | 407 | — |
-| reference | tween-animation/looping-and-signals.md | 1736 | 1.7 | 434 | 580 | 488 | — |
-| reference | physics-system/interpolation-camera.md | 1734 | 1.7 | 434 | 484 | 428 | — |
-| reference | shader-basics/3d-shader-recipes.md | 1703 | 1.7 | 426 | 629 | 554 | — |
-| reference | tween-animation/property-tweener-modifiers.md | 1632 | 1.6 | 408 | 591 | 510 | — |
-| reference | tween-animation/lifecycle.md | 1569 | 1.5 | 392 | 552 | 421 | — |
-| reference | mobile-development/crash-debugging.md | 1280 | 1.3 | 320 | 342 | 306 | — |
-| reference | xr-development/passthrough.md | 1265 | 1.2 | 316 | 349 | 298 | — |
-| reference | input-handling/touch.md | 1229 | 1.2 | 307 | 317 | 279 | — |
-| reference | animation-system/retargeting.md | 838 | 0.8 | 210 | 228 | 208 | — |
-| reference | using-godot-prompter/gemini-tools.md | 742 | 0.7 | 186 | 232 | 206 | — |
-| reference | using-godot-prompter/cursor-tools.md | 734 | 0.7 | 184 | 216 | 191 | — |
-| reference | using-godot-prompter/copilot-tools.md | 712 | 0.7 | 178 | 226 | 209 | — |
-| reference | using-godot-prompter/codex-tools.md | 688 | 0.7 | 172 | 199 | 178 | — |
+| reference | ability-system/tags-and-conditions.md | 18567 | 18.1 | 4642 | — | — | — |
+| skill | animation-system | 16364 | 16.0 | 4091 | — | — | ✓ under budget |
+| skill | 3d-essentials | 16307 | 15.9 | 4077 | — | — | ✓ under budget |
+| skill | physics-system | 16300 | 15.9 | 4075 | — | — | ✓ under budget |
+| skill | ai-navigation | 16231 | 15.9 | 4058 | — | — | ✓ under budget |
+| skill | multiplayer-basics | 15997 | 15.6 | 3999 | — | — | ✓ under budget |
+| skill | event-bus | 15935 | 15.6 | 3984 | — | — | ✓ under budget |
+| skill | shader-basics | 15826 | 15.5 | 3957 | — | — | ✓ under budget |
+| skill | localization | 15649 | 15.3 | 3912 | — | — | ✓ under budget |
+| skill | assets-pipeline | 15592 | 15.2 | 3898 | — | — | ✓ under budget |
+| reference | ability-system/stat-modifiers.md | 15551 | 15.2 | 3888 | — | — | — |
+| skill | xr-development | 15344 | 15.0 | 3836 | — | — | ✓ under budget |
+| skill | gdscript-patterns | 15141 | 14.8 | 3785 | — | — | ✓ under budget |
+| skill | input-handling | 14955 | 14.6 | 3739 | — | — | ✓ under budget |
+| skill | godot-code-review | 14602 | 14.3 | 3651 | — | — | ✓ under budget |
+| skill | particles-vfx | 14564 | 14.2 | 3641 | — | — | ✓ under budget |
+| skill | state-machine | 14495 | 14.2 | 3624 | — | — | ✓ under budget |
+| skill | godot-brainstorming | 14097 | 13.8 | 3524 | — | — | ✓ under budget |
+| skill | godot-ui | 14061 | 13.7 | 3515 | — | — | ✓ under budget |
+| skill | component-system | 14009 | 13.7 | 3502 | — | — | ✓ under budget |
+| skill | export-pipeline | 14005 | 13.7 | 3501 | — | — | ✓ under budget |
+| skill | csharp-godot | 13944 | 13.6 | 3486 | — | — | ✓ under budget |
+| skill | player-controller | 13918 | 13.6 | 3480 | — | — | ✓ under budget |
+| skill | audio-system | 13901 | 13.6 | 3475 | — | — | ✓ under budget |
+| skill | inventory-system | 13872 | 13.5 | 3468 | — | — | ✓ under budget |
+| skill | tween-animation | 13528 | 13.2 | 3382 | — | — | ✓ under budget |
+| skill | addon-development | 13447 | 13.1 | 3362 | — | — | ✓ under budget |
+| reference | save-load/json-saves.md | 12833 | 12.5 | 3208 | — | — | — |
+| skill | limboai | 12827 | 12.5 | 3207 | — | — | ✓ under budget |
+| skill | godot-project-setup | 12817 | 12.5 | 3204 | — | — | ✓ under budget |
+| skill | math-essentials | 12716 | 12.4 | 3179 | — | — | ✓ under budget |
+| skill | resource-pattern | 12545 | 12.3 | 3136 | — | — | ✓ under budget |
+| skill | godot-debugging | 12259 | 12.0 | 3065 | — | — | ✓ under budget |
+| skill | ability-system | 12155 | 11.9 | 3039 | — | — | ✓ under budget |
+| skill | using-godot-prompter | 11979 | 11.7 | 2995 | — | — | ✓ under budget |
+| skill | godot-optimization | 11865 | 11.6 | 2966 | — | — | ✓ under budget |
+| skill | dedicated-server | 11715 | 11.4 | 2929 | — | — | ✓ under budget |
+| skill | hud-system | 11548 | 11.3 | 2887 | — | — | ✓ under budget |
+| skill | dependency-injection | 11334 | 11.1 | 2834 | — | — | ✓ under budget |
+| skill | camera-system | 11038 | 10.8 | 2760 | — | — | ✓ under budget |
+| skill | dialogue-system | 10898 | 10.6 | 2725 | — | — | ✓ under budget |
+| skill | beehave | 10871 | 10.6 | 2718 | — | — | ✓ under budget |
+| skill | multiplayer-sync | 10659 | 10.4 | 2665 | — | — | ✓ under budget |
+| skill | scene-organization | 10447 | 10.2 | 2612 | — | — | ✓ under budget |
+| reference | godot-optimization/memory-management.md | 10420 | 10.2 | 2605 | — | — | — |
+| skill | multithreading | 10367 | 10.1 | 2592 | — | — | ✓ under budget |
+| reference | ability-system/ui-binding.md | 10207 | 10.0 | 2552 | — | — | — |
+| skill | gdscript-advanced | 10075 | 9.8 | 2519 | — | — | ✓ under budget |
+| skill | csharp-signals | 9651 | 9.4 | 2413 | — | — | ✓ under budget |
+| skill | godot-testing | 9564 | 9.3 | 2391 | — | — | ✓ under budget |
+| reference | dedicated-server/lobby-management.md | 9121 | 8.9 | 2280 | — | — | — |
+| skill | gdextension | 8949 | 8.7 | 2237 | — | — | ✓ under budget |
+| skill | responsive-ui | 8912 | 8.7 | 2228 | — | — | ✓ under budget |
+| skill | 2d-essentials | 8814 | 8.6 | 2204 | — | — | ✓ under budget |
+| reference | addon-development/inspector-plugins.md | 8649 | 8.4 | 2162 | — | — | — |
+| reference | ai-navigation/chase-attack.md | 8531 | 8.3 | 2133 | — | — | — |
+| reference | dialogue-system/ui-presentation.md | 8498 | 8.3 | 2125 | — | — | — |
+| skill | mobile-development | 8192 | 8.0 | 2048 | — | — | ✓ under budget |
+| reference | godot-optimization/cpu-bottlenecks.md | 7642 | 7.5 | 1911 | — | — | — |
+| reference | godot-ui/ui-patterns.md | 7611 | 7.4 | 1903 | — | — | — |
+| reference | dialogue-system/dialogue-manager.md | 7540 | 7.4 | 1885 | — | — | — |
+| reference | procedural-generation/wave-function-collapse.md | 7334 | 7.2 | 1834 | — | — | — |
+| reference | inventory-system/ui-binding.md | 6873 | 6.7 | 1718 | — | — | — |
+| reference | godot-optimization/draw-calls.md | 6785 | 6.6 | 1696 | — | — | — |
+| reference | addon-development/gizmos-deep-dive.md | 6717 | 6.6 | 1679 | — | — | — |
+| reference | animation-system/ik-recipes.md | 6608 | 6.5 | 1652 | — | — | — |
+| reference | procedural-generation/bsp-dungeons.md | 6542 | 6.4 | 1636 | — | — | — |
+| reference | camera-system/camera3d-patterns.md | 6471 | 6.3 | 1618 | — | — | — |
+| reference | hud-system/damage-numbers.md | 6451 | 6.3 | 1613 | — | — | — |
+| reference | dedicated-server/match-flow.md | 6433 | 6.3 | 1608 | — | — | — |
+| reference | event-bus/testing.md | 6372 | 6.2 | 1593 | — | — | — |
+| reference | 3d-essentials/environment-and-post.md | 6266 | 6.1 | 1567 | — | — | — |
+| reference | ai-navigation/behavior-trees.md | 6266 | 6.1 | 1567 | — | — | — |
+| reference | ai-navigation/steering-behaviors.md | 6086 | 5.9 | 1522 | — | — | — |
+| reference | godot-testing/tdd-workflow.md | 5945 | 5.8 | 1486 | — | — | — |
+| agent | godot-tools-engineer | 5931 | 5.8 | 1483 | — | — | — |
+| reference | physics-system/rigidbody-recipes.md | 5891 | 5.8 | 1473 | — | — | — |
+| reference | tween-animation/common-recipes.md | 5726 | 5.6 | 1432 | — | — | — |
+| agent | godot-csharp-engineer | 5726 | 5.6 | 1432 | — | — | — |
+| reference | inventory-system/serialization.md | 5705 | 5.6 | 1426 | — | — | — |
+| reference | multiplayer-sync/client-prediction.md | 5614 | 5.5 | 1404 | — | — | — |
+| reference | beehave/custom-nodes.md | 5518 | 5.4 | 1380 | — | — | — |
+| reference | multiplayer-sync/lag-compensation.md | 5517 | 5.4 | 1379 | — | — | — |
+| reference | godot-debugging/signal-tracing.md | 5452 | 5.3 | 1363 | — | — | — |
+| reference | hud-system/interaction-prompts.md | 5451 | 5.3 | 1363 | — | — | — |
+| reference | input-handling/action-rebinding.md | 5369 | 5.2 | 1342 | — | — | — |
+| reference | audio-system/interactive-music.md | 5333 | 5.2 | 1333 | — | — | — |
+| agent | godot-animator | 5266 | 5.1 | 1317 | — | — | — |
+| reference | state-machine/hierarchical-and-parallel.md | 5241 | 5.1 | 1310 | — | — | — |
+| agent | godot-ui-designer | 5088 | 5.0 | 1272 | — | — | — |
+| reference | dedicated-server/server-config.md | 5002 | 4.9 | 1251 | — | — | — |
+| reference | csharp-signals/custom-signal-patterns.md | 4993 | 4.9 | 1248 | — | — | — |
+| skill | procedural-generation | 4975 | 4.9 | 1244 | — | — | ✓ under budget |
+| reference | 2d-essentials/tilemap.md | 4969 | 4.9 | 1242 | — | — | — |
+| reference | dependency-injection/service-locator.md | 4914 | 4.8 | 1229 | — | — | — |
+| reference | camera-system/transitions.md | 4886 | 4.8 | 1222 | — | — | — |
+| reference | dialogue-system/branching-and-conditions.md | 4871 | 4.8 | 1218 | — | — | — |
+| reference | particles-vfx/vfx-recipes.md | 4803 | 4.7 | 1201 | — | — | — |
+| reference | responsive-ui/mobile.md | 4787 | 4.7 | 1197 | — | — | — |
+| reference | limboai/hsm.md | 4780 | 4.7 | 1195 | — | — | — |
+| reference | godot-optimization/physics-tuning.md | 4754 | 4.6 | 1189 | — | — | — |
+| skill | save-load | 4742 | 4.6 | 1186 | — | — | ✓ under budget |
+| agent | godot-game-dev | 4707 | 4.6 | 1177 | — | — | — |
+| agent | godot-performance-profiler | 4672 | 4.6 | 1168 | — | — | — |
+| reference | procedural-generation/cellular-automata.md | 4655 | 4.5 | 1164 | — | — | — |
+| reference | godot-brainstorming/example-chest.md | 4578 | 4.5 | 1145 | — | — | — |
+| reference | input-handling/mouse.md | 4510 | 4.4 | 1128 | — | — | — |
+| reference | dialogue-system/external-formats.md | 4491 | 4.4 | 1123 | — | — | — |
+| reference | audio-system/sfx-pooling.md | 4469 | 4.4 | 1117 | — | — | — |
+| agent | godot-game-architect | 4445 | 4.3 | 1111 | — | — | — |
+| reference | multiplayer-sync/bandwidth-optimization.md | 4431 | 4.3 | 1108 | — | — | — |
+| reference | using-godot-prompter/antigravity-tools.md | 4378 | 4.3 | 1095 | — | — | — |
+| reference | godot-testing/testing-patterns.md | 4377 | 4.3 | 1094 | — | — | — |
+| reference | godot-debugging/performance-debugging.md | 4315 | 4.2 | 1079 | — | — | — |
+| agent | godot-shader-author | 4264 | 4.2 | 1066 | — | — | — |
+| reference | player-controller/common-movement-recipes.md | 4257 | 4.2 | 1064 | — | — | — |
+| reference | godot-debugging/systematic-method.md | 4245 | 4.1 | 1061 | — | — | — |
+| reference | shader-basics/compositor-effects.md | 4228 | 4.1 | 1057 | — | — | — |
+| reference | input-handling/gamepad.md | 4218 | 4.1 | 1055 | — | — | — |
+| reference | inventory-system/equipment.md | 4191 | 4.1 | 1048 | — | — | — |
+| reference | multiplayer-basics/player-join-flow.md | 4188 | 4.1 | 1047 | — | — | — |
+| reference | multithreading/pitfalls.md | 4182 | 4.1 | 1046 | — | — | — |
+| reference | hud-system/notifications.md | 4179 | 4.1 | 1045 | — | — | — |
+| reference | save-load/save-architecture.md | 4160 | 4.1 | 1040 | — | — | — |
+| reference | 2d-essentials/2d-particles.md | 4083 | 4.0 | 1021 | — | — | — |
+| reference | dedicated-server/deployment.md | 4071 | 4.0 | 1018 | — | — | — |
+| reference | 2d-essentials/lights-and-shadows.md | 4006 | 3.9 | 1002 | — | — | — |
+| reference | 3d-essentials/materials-and-lighting-recipes.md | 3959 | 3.9 | 990 | — | — | — |
+| reference | procedural-generation/noise-generation.md | 3958 | 3.9 | 990 | — | — | — |
+| reference | mobile-development/plugins.md | 3879 | 3.8 | 970 | — | — | — |
+| reference | shader-basics/2d-shader-recipes.md | 3707 | 3.6 | 927 | — | — | — |
+| reference | audio-system/music-manager.md | 3649 | 3.6 | 912 | — | — | — |
+| agent | godot-code-reviewer | 3642 | 3.6 | 911 | — | — | — |
+| reference | audio-system/audio-settings.md | 3635 | 3.5 | 909 | — | — | — |
+| reference | godot-ui/theme-system.md | 3601 | 3.5 | 900 | — | — | — |
+| reference | dependency-injection/testing-with-di.md | 3558 | 3.5 | 890 | — | — | — |
+| reference | hud-system/minimap.md | 3528 | 3.4 | 882 | — | — | — |
+| reference | camera-system/camera-zones.md | 3506 | 3.4 | 877 | — | — | — |
+| reference | physics-system/raycasting-recipes.md | 3493 | 3.4 | 873 | — | — | — |
+| reference | resource-pattern/configuration-pattern.md | 3481 | 3.4 | 870 | — | — | — |
+| reference | save-load/configfile.md | 3445 | 3.4 | 861 | — | — | — |
+| reference | 3d-essentials/lod-and-culling.md | 3404 | 3.3 | 851 | — | — | — |
+| reference | physics-system/softbody-recipes.md | 3376 | 3.3 | 844 | — | — | — |
+| reference | resource-pattern/collections.md | 3375 | 3.3 | 844 | — | — | — |
+| reference | particles-vfx/attractors-and-collision.md | 3346 | 3.3 | 837 | — | — | — |
+| reference | xr-development/controllers-and-input.md | 3293 | 3.2 | 823 | — | — | — |
+| reference | camera-system/split-screen.md | 3253 | 3.2 | 813 | — | — | — |
+| reference | godot-debugging/scene-tree-debugging.md | 3218 | 3.1 | 805 | — | — | — |
+| reference | multiplayer-basics/disconnect-handling.md | 3212 | 3.1 | 803 | — | — | — |
+| reference | animation-system/bone-constraints.md | 3207 | 3.1 | 802 | — | — | — |
+| reference | xr-development/grabbing-objects.md | 3182 | 3.1 | 796 | — | — | — |
+| reference | multiplayer-sync/interpolation.md | 3169 | 3.1 | 792 | — | — | — |
+| reference | multiplayer-basics/spawning-networked-objects.md | 3144 | 3.1 | 786 | — | — | — |
+| reference | 2d-essentials/custom-drawing.md | 3119 | 3.0 | 780 | — | — | — |
+| reference | mobile-development/iap-and-ads.md | 3050 | 3.0 | 763 | — | — | — |
+| reference | export-pipeline/distribution-itch-steam.md | 3026 | 3.0 | 757 | — | — | — |
+| reference | ai-navigation/patrol-patterns.md | 2992 | 2.9 | 748 | — | — | — |
+| reference | responsive-ui/adaptive-layouts.md | 2888 | 2.8 | 722 | — | — | — |
+| reference | 3d-essentials/fog-recipes.md | 2875 | 2.8 | 719 | — | — | — |
+| reference | shader-basics/stencil-buffer.md | 2856 | 2.8 | 714 | — | — | — |
+| reference | godot-ui/focus-and-navigation.md | 2845 | 2.8 | 711 | — | — | — |
+| reference | math-essentials/random-numbers.md | 2792 | 2.7 | 698 | — | — | — |
+| reference | 2d-essentials/parallax.md | 2776 | 2.7 | 694 | — | — | — |
+| reference | gdscript-patterns/super-in-virtual-methods.md | 2771 | 2.7 | 693 | — | — | — |
+| reference | shader-basics/post-processing.md | 2735 | 2.7 | 684 | — | — | — |
+| reference | math-essentials/game-math-recipes.md | 2727 | 2.7 | 682 | — | — | — |
+| reference | dependency-injection/autoloads.md | 2649 | 2.6 | 662 | — | — | — |
+| reference | responsive-ui/pixel-art-setup.md | 2644 | 2.6 | 661 | — | — | — |
+| reference | dependency-injection/export-injection.md | 2593 | 2.5 | 648 | — | — | — |
+| reference | gdscript-patterns/common-idioms.md | 2586 | 2.5 | 647 | — | — | — |
+| reference | godot-testing/running-tests.md | 2577 | 2.5 | 644 | — | — | — |
+| reference | csharp-signals/disconnecting.md | 2560 | 2.5 | 640 | — | — | — |
+| reference | csharp-signals/awaiting-signals.md | 2550 | 2.5 | 638 | — | — | — |
+| reference | 3d-essentials/global-illumination.md | 2545 | 2.5 | 636 | — | — | — |
+| reference | physics-system/ragdoll-recipes.md | 2528 | 2.5 | 632 | — | — | — |
+| reference | xr-development/hand-tracking.md | 2519 | 2.5 | 630 | — | — | — |
+| reference | resource-pattern/editor-integration.md | 2503 | 2.4 | 626 | — | — | — |
+| reference | gdscript-advanced/profiler-recipes.md | 2497 | 2.4 | 624 | — | — | — |
+| reference | godot-ui/signals.md | 2472 | 2.4 | 618 | — | — | — |
+| reference | export-pipeline/ci-cd-github-actions.md | 2460 | 2.4 | 615 | — | — | — |
+| reference | 3d-essentials/decals.md | 2459 | 2.4 | 615 | — | — | — |
+| reference | gdscript-patterns/abstract-classes.md | 2422 | 2.4 | 606 | — | — | — |
+| reference | dependency-injection/scene-injection.md | 2402 | 2.3 | 601 | — | — | — |
+| reference | dialogue-system/variable-interpolation.md | 2386 | 2.3 | 597 | — | — | — |
+| reference | save-load/version-migration.md | 2368 | 2.3 | 592 | — | — | — |
+| reference | gdscript-advanced/tool-script-recipes.md | 2350 | 2.3 | 588 | — | — | — |
+| reference | particles-vfx/subemitters.md | 2319 | 2.3 | 580 | — | — | — |
+| reference | physics-system/area-recipes.md | 2233 | 2.2 | 558 | — | — | — |
+| reference | animation-system/sprite-animation.md | 2195 | 2.1 | 549 | — | — | — |
+| reference | gdextension/debugging-native.md | 2132 | 2.1 | 533 | — | — | — |
+| reference | resource-pattern/sharing-vs-unique.md | 2122 | 2.1 | 531 | — | — | — |
+| reference | addon-development/dock-panels.md | 2086 | 2.0 | 522 | — | — | — |
+| reference | gdscript-advanced/metaprogramming-recipes.md | 2081 | 2.0 | 520 | — | — | — |
+| reference | particles-vfx/trails.md | 2007 | 2.0 | 502 | — | — | — |
+| reference | animation-system/skeleton-modifiers.md | 2000 | 2.0 | 500 | — | — | — |
+| reference | gdextension/rust-gdext.md | 1998 | 2.0 | 500 | — | — | — |
+| reference | xr-development/xr-ui.md | 1985 | 1.9 | 496 | — | — | — |
+| reference | math-essentials/curves-and-paths.md | 1895 | 1.9 | 474 | — | — | — |
+| reference | animation-system/common-recipes.md | 1892 | 1.8 | 473 | — | — | — |
+| reference | resource-pattern/saving-resources.md | 1882 | 1.8 | 471 | — | — | — |
+| reference | physics-system/staticbody-recipes.md | 1879 | 1.8 | 470 | — | — | — |
+| reference | responsive-ui/dpi-scaling.md | 1845 | 1.8 | 461 | — | — | — |
+| reference | gdscript-patterns/export-annotations.md | 1821 | 1.8 | 455 | — | — | — |
+| reference | gdscript-patterns/variadic-functions.md | 1805 | 1.8 | 451 | — | — | — |
+| reference | particles-vfx/flipbook-animation.md | 1781 | 1.7 | 445 | — | — | — |
+| reference | csharp-signals/connecting-gdscript-signals.md | 1770 | 1.7 | 443 | — | — | — |
+| reference | tween-animation/looping-and-signals.md | 1736 | 1.7 | 434 | — | — | — |
+| reference | physics-system/interpolation-camera.md | 1734 | 1.7 | 434 | — | — | — |
+| reference | shader-basics/3d-shader-recipes.md | 1703 | 1.7 | 426 | — | — | — |
+| reference | tween-animation/property-tweener-modifiers.md | 1632 | 1.6 | 408 | — | — | — |
+| reference | tween-animation/lifecycle.md | 1569 | 1.5 | 392 | — | — | — |
+| reference | mobile-development/crash-debugging.md | 1280 | 1.3 | 320 | — | — | — |
+| reference | xr-development/passthrough.md | 1265 | 1.2 | 316 | — | — | — |
+| reference | input-handling/touch.md | 1229 | 1.2 | 307 | — | — | — |
+| reference | animation-system/retargeting.md | 838 | 0.8 | 210 | — | — | — |
+| reference | using-godot-prompter/gemini-tools.md | 742 | 0.7 | 186 | — | — | — |
+| reference | using-godot-prompter/cursor-tools.md | 734 | 0.7 | 184 | — | — | — |
+| reference | using-godot-prompter/copilot-tools.md | 712 | 0.7 | 178 | — | — | — |
+| reference | using-godot-prompter/codex-tools.md | 688 | 0.7 | 172 | — | — | — |
 <!-- END-TOKEN-TABLE -->
 
 ## How to read this

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -27,225 +27,225 @@ Columns:
 <!-- BEGIN-TOKEN-TABLE -->
 | Kind | Name | Bytes | KB | Est. tokens | Claude | GPT | Status |
 |---|---|---:|---:|---:|---:|---:|---|
-| reference | ability-system/tags-and-conditions.md | 18567 | 18.1 | 4642 | — | — | — |
-| skill | animation-system | 16364 | 16.0 | 4091 | — | — | ✓ under budget |
-| skill | 3d-essentials | 16307 | 15.9 | 4077 | — | — | ✓ under budget |
-| skill | physics-system | 16300 | 15.9 | 4075 | — | — | ✓ under budget |
-| skill | ai-navigation | 16231 | 15.9 | 4058 | — | — | ✓ under budget |
-| skill | multiplayer-basics | 15997 | 15.6 | 3999 | — | — | ✓ under budget |
-| skill | event-bus | 15935 | 15.6 | 3984 | — | — | ✓ under budget |
-| skill | shader-basics | 15826 | 15.5 | 3957 | — | — | ✓ under budget |
-| skill | localization | 15649 | 15.3 | 3912 | — | — | ✓ under budget |
-| skill | assets-pipeline | 15592 | 15.2 | 3898 | — | — | ✓ under budget |
-| reference | ability-system/stat-modifiers.md | 15551 | 15.2 | 3888 | — | — | — |
-| skill | xr-development | 15344 | 15.0 | 3836 | — | — | ✓ under budget |
-| skill | gdscript-patterns | 15141 | 14.8 | 3785 | — | — | ✓ under budget |
-| skill | input-handling | 14955 | 14.6 | 3739 | — | — | ✓ under budget |
-| skill | godot-code-review | 14602 | 14.3 | 3651 | — | — | ✓ under budget |
-| skill | particles-vfx | 14564 | 14.2 | 3641 | — | — | ✓ under budget |
-| skill | state-machine | 14495 | 14.2 | 3624 | — | — | ✓ under budget |
-| skill | godot-brainstorming | 14097 | 13.8 | 3524 | — | — | ✓ under budget |
-| skill | godot-ui | 14061 | 13.7 | 3515 | — | — | ✓ under budget |
-| skill | component-system | 14009 | 13.7 | 3502 | — | — | ✓ under budget |
-| skill | export-pipeline | 14005 | 13.7 | 3501 | — | — | ✓ under budget |
-| skill | csharp-godot | 13944 | 13.6 | 3486 | — | — | ✓ under budget |
-| skill | player-controller | 13918 | 13.6 | 3480 | — | — | ✓ under budget |
-| skill | audio-system | 13901 | 13.6 | 3475 | — | — | ✓ under budget |
-| skill | inventory-system | 13872 | 13.5 | 3468 | — | — | ✓ under budget |
-| skill | tween-animation | 13528 | 13.2 | 3382 | — | — | ✓ under budget |
-| skill | addon-development | 13447 | 13.1 | 3362 | — | — | ✓ under budget |
-| reference | save-load/json-saves.md | 12833 | 12.5 | 3208 | — | — | — |
-| skill | limboai | 12827 | 12.5 | 3207 | — | — | ✓ under budget |
-| skill | godot-project-setup | 12817 | 12.5 | 3204 | — | — | ✓ under budget |
-| skill | math-essentials | 12716 | 12.4 | 3179 | — | — | ✓ under budget |
-| skill | resource-pattern | 12545 | 12.3 | 3136 | — | — | ✓ under budget |
-| skill | godot-debugging | 12259 | 12.0 | 3065 | — | — | ✓ under budget |
-| skill | ability-system | 12155 | 11.9 | 3039 | — | — | ✓ under budget |
-| skill | using-godot-prompter | 11979 | 11.7 | 2995 | — | — | ✓ under budget |
-| skill | godot-optimization | 11865 | 11.6 | 2966 | — | — | ✓ under budget |
-| skill | dedicated-server | 11715 | 11.4 | 2929 | — | — | ✓ under budget |
-| skill | hud-system | 11548 | 11.3 | 2887 | — | — | ✓ under budget |
-| skill | dependency-injection | 11334 | 11.1 | 2834 | — | — | ✓ under budget |
-| skill | camera-system | 11038 | 10.8 | 2760 | — | — | ✓ under budget |
-| skill | dialogue-system | 10898 | 10.6 | 2725 | — | — | ✓ under budget |
-| skill | beehave | 10871 | 10.6 | 2718 | — | — | ✓ under budget |
-| skill | multiplayer-sync | 10659 | 10.4 | 2665 | — | — | ✓ under budget |
-| skill | scene-organization | 10447 | 10.2 | 2612 | — | — | ✓ under budget |
-| reference | godot-optimization/memory-management.md | 10420 | 10.2 | 2605 | — | — | — |
-| skill | multithreading | 10367 | 10.1 | 2592 | — | — | ✓ under budget |
-| reference | ability-system/ui-binding.md | 10207 | 10.0 | 2552 | — | — | — |
-| skill | gdscript-advanced | 10075 | 9.8 | 2519 | — | — | ✓ under budget |
-| skill | csharp-signals | 9651 | 9.4 | 2413 | — | — | ✓ under budget |
-| skill | godot-testing | 9564 | 9.3 | 2391 | — | — | ✓ under budget |
-| reference | dedicated-server/lobby-management.md | 9121 | 8.9 | 2280 | — | — | — |
-| skill | gdextension | 8949 | 8.7 | 2237 | — | — | ✓ under budget |
-| skill | responsive-ui | 8912 | 8.7 | 2228 | — | — | ✓ under budget |
-| skill | 2d-essentials | 8814 | 8.6 | 2204 | — | — | ✓ under budget |
-| reference | addon-development/inspector-plugins.md | 8649 | 8.4 | 2162 | — | — | — |
-| reference | ai-navigation/chase-attack.md | 8531 | 8.3 | 2133 | — | — | — |
-| reference | dialogue-system/ui-presentation.md | 8498 | 8.3 | 2125 | — | — | — |
-| skill | mobile-development | 8192 | 8.0 | 2048 | — | — | ✓ under budget |
-| reference | godot-optimization/cpu-bottlenecks.md | 7642 | 7.5 | 1911 | — | — | — |
-| reference | godot-ui/ui-patterns.md | 7611 | 7.4 | 1903 | — | — | — |
-| reference | dialogue-system/dialogue-manager.md | 7540 | 7.4 | 1885 | — | — | — |
-| reference | procedural-generation/wave-function-collapse.md | 7334 | 7.2 | 1834 | — | — | — |
-| reference | inventory-system/ui-binding.md | 6873 | 6.7 | 1718 | — | — | — |
-| reference | godot-optimization/draw-calls.md | 6785 | 6.6 | 1696 | — | — | — |
-| reference | addon-development/gizmos-deep-dive.md | 6717 | 6.6 | 1679 | — | — | — |
-| reference | animation-system/ik-recipes.md | 6608 | 6.5 | 1652 | — | — | — |
-| reference | procedural-generation/bsp-dungeons.md | 6542 | 6.4 | 1636 | — | — | — |
-| reference | camera-system/camera3d-patterns.md | 6471 | 6.3 | 1618 | — | — | — |
-| reference | hud-system/damage-numbers.md | 6451 | 6.3 | 1613 | — | — | — |
-| reference | dedicated-server/match-flow.md | 6433 | 6.3 | 1608 | — | — | — |
-| reference | event-bus/testing.md | 6372 | 6.2 | 1593 | — | — | — |
-| reference | 3d-essentials/environment-and-post.md | 6266 | 6.1 | 1567 | — | — | — |
-| reference | ai-navigation/behavior-trees.md | 6266 | 6.1 | 1567 | — | — | — |
-| reference | ai-navigation/steering-behaviors.md | 6086 | 5.9 | 1522 | — | — | — |
-| reference | godot-testing/tdd-workflow.md | 5945 | 5.8 | 1486 | — | — | — |
-| agent | godot-tools-engineer | 5931 | 5.8 | 1483 | — | — | — |
-| reference | physics-system/rigidbody-recipes.md | 5891 | 5.8 | 1473 | — | — | — |
-| reference | tween-animation/common-recipes.md | 5726 | 5.6 | 1432 | — | — | — |
-| agent | godot-csharp-engineer | 5726 | 5.6 | 1432 | — | — | — |
-| reference | inventory-system/serialization.md | 5705 | 5.6 | 1426 | — | — | — |
-| reference | multiplayer-sync/client-prediction.md | 5614 | 5.5 | 1404 | — | — | — |
-| reference | beehave/custom-nodes.md | 5518 | 5.4 | 1380 | — | — | — |
-| reference | multiplayer-sync/lag-compensation.md | 5517 | 5.4 | 1379 | — | — | — |
-| reference | godot-debugging/signal-tracing.md | 5452 | 5.3 | 1363 | — | — | — |
-| reference | hud-system/interaction-prompts.md | 5451 | 5.3 | 1363 | — | — | — |
-| reference | input-handling/action-rebinding.md | 5369 | 5.2 | 1342 | — | — | — |
-| reference | audio-system/interactive-music.md | 5333 | 5.2 | 1333 | — | — | — |
-| agent | godot-animator | 5266 | 5.1 | 1317 | — | — | — |
-| reference | state-machine/hierarchical-and-parallel.md | 5241 | 5.1 | 1310 | — | — | — |
-| agent | godot-ui-designer | 5088 | 5.0 | 1272 | — | — | — |
-| reference | dedicated-server/server-config.md | 5002 | 4.9 | 1251 | — | — | — |
-| reference | csharp-signals/custom-signal-patterns.md | 4993 | 4.9 | 1248 | — | — | — |
-| skill | procedural-generation | 4975 | 4.9 | 1244 | — | — | ✓ under budget |
-| reference | 2d-essentials/tilemap.md | 4969 | 4.9 | 1242 | — | — | — |
-| reference | dependency-injection/service-locator.md | 4914 | 4.8 | 1229 | — | — | — |
-| reference | camera-system/transitions.md | 4886 | 4.8 | 1222 | — | — | — |
-| reference | dialogue-system/branching-and-conditions.md | 4871 | 4.8 | 1218 | — | — | — |
-| reference | particles-vfx/vfx-recipes.md | 4803 | 4.7 | 1201 | — | — | — |
-| reference | responsive-ui/mobile.md | 4787 | 4.7 | 1197 | — | — | — |
-| reference | limboai/hsm.md | 4780 | 4.7 | 1195 | — | — | — |
-| reference | godot-optimization/physics-tuning.md | 4754 | 4.6 | 1189 | — | — | — |
-| skill | save-load | 4742 | 4.6 | 1186 | — | — | ✓ under budget |
-| agent | godot-game-dev | 4707 | 4.6 | 1177 | — | — | — |
-| agent | godot-performance-profiler | 4672 | 4.6 | 1168 | — | — | — |
-| reference | procedural-generation/cellular-automata.md | 4655 | 4.5 | 1164 | — | — | — |
-| reference | godot-brainstorming/example-chest.md | 4578 | 4.5 | 1145 | — | — | — |
-| reference | input-handling/mouse.md | 4510 | 4.4 | 1128 | — | — | — |
-| reference | dialogue-system/external-formats.md | 4491 | 4.4 | 1123 | — | — | — |
-| reference | audio-system/sfx-pooling.md | 4469 | 4.4 | 1117 | — | — | — |
-| agent | godot-game-architect | 4445 | 4.3 | 1111 | — | — | — |
-| reference | multiplayer-sync/bandwidth-optimization.md | 4431 | 4.3 | 1108 | — | — | — |
-| reference | using-godot-prompter/antigravity-tools.md | 4378 | 4.3 | 1095 | — | — | — |
-| reference | godot-testing/testing-patterns.md | 4377 | 4.3 | 1094 | — | — | — |
-| reference | godot-debugging/performance-debugging.md | 4315 | 4.2 | 1079 | — | — | — |
-| agent | godot-shader-author | 4264 | 4.2 | 1066 | — | — | — |
-| reference | player-controller/common-movement-recipes.md | 4257 | 4.2 | 1064 | — | — | — |
-| reference | godot-debugging/systematic-method.md | 4245 | 4.1 | 1061 | — | — | — |
-| reference | shader-basics/compositor-effects.md | 4228 | 4.1 | 1057 | — | — | — |
-| reference | input-handling/gamepad.md | 4218 | 4.1 | 1055 | — | — | — |
-| reference | inventory-system/equipment.md | 4191 | 4.1 | 1048 | — | — | — |
-| reference | multiplayer-basics/player-join-flow.md | 4188 | 4.1 | 1047 | — | — | — |
-| reference | multithreading/pitfalls.md | 4182 | 4.1 | 1046 | — | — | — |
-| reference | hud-system/notifications.md | 4179 | 4.1 | 1045 | — | — | — |
-| reference | save-load/save-architecture.md | 4160 | 4.1 | 1040 | — | — | — |
-| reference | 2d-essentials/2d-particles.md | 4083 | 4.0 | 1021 | — | — | — |
-| reference | dedicated-server/deployment.md | 4071 | 4.0 | 1018 | — | — | — |
-| reference | 2d-essentials/lights-and-shadows.md | 4006 | 3.9 | 1002 | — | — | — |
-| reference | 3d-essentials/materials-and-lighting-recipes.md | 3959 | 3.9 | 990 | — | — | — |
-| reference | procedural-generation/noise-generation.md | 3958 | 3.9 | 990 | — | — | — |
-| reference | mobile-development/plugins.md | 3879 | 3.8 | 970 | — | — | — |
-| reference | shader-basics/2d-shader-recipes.md | 3707 | 3.6 | 927 | — | — | — |
-| reference | audio-system/music-manager.md | 3649 | 3.6 | 912 | — | — | — |
-| agent | godot-code-reviewer | 3642 | 3.6 | 911 | — | — | — |
-| reference | audio-system/audio-settings.md | 3635 | 3.5 | 909 | — | — | — |
-| reference | godot-ui/theme-system.md | 3601 | 3.5 | 900 | — | — | — |
-| reference | dependency-injection/testing-with-di.md | 3558 | 3.5 | 890 | — | — | — |
-| reference | hud-system/minimap.md | 3528 | 3.4 | 882 | — | — | — |
-| reference | camera-system/camera-zones.md | 3506 | 3.4 | 877 | — | — | — |
-| reference | physics-system/raycasting-recipes.md | 3493 | 3.4 | 873 | — | — | — |
-| reference | resource-pattern/configuration-pattern.md | 3481 | 3.4 | 870 | — | — | — |
-| reference | save-load/configfile.md | 3445 | 3.4 | 861 | — | — | — |
-| reference | 3d-essentials/lod-and-culling.md | 3404 | 3.3 | 851 | — | — | — |
-| reference | physics-system/softbody-recipes.md | 3376 | 3.3 | 844 | — | — | — |
-| reference | resource-pattern/collections.md | 3375 | 3.3 | 844 | — | — | — |
-| reference | particles-vfx/attractors-and-collision.md | 3346 | 3.3 | 837 | — | — | — |
-| reference | xr-development/controllers-and-input.md | 3293 | 3.2 | 823 | — | — | — |
-| reference | camera-system/split-screen.md | 3253 | 3.2 | 813 | — | — | — |
-| reference | godot-debugging/scene-tree-debugging.md | 3218 | 3.1 | 805 | — | — | — |
-| reference | multiplayer-basics/disconnect-handling.md | 3212 | 3.1 | 803 | — | — | — |
-| reference | animation-system/bone-constraints.md | 3207 | 3.1 | 802 | — | — | — |
-| reference | xr-development/grabbing-objects.md | 3182 | 3.1 | 796 | — | — | — |
-| reference | multiplayer-sync/interpolation.md | 3169 | 3.1 | 792 | — | — | — |
-| reference | multiplayer-basics/spawning-networked-objects.md | 3144 | 3.1 | 786 | — | — | — |
-| reference | 2d-essentials/custom-drawing.md | 3119 | 3.0 | 780 | — | — | — |
-| reference | mobile-development/iap-and-ads.md | 3050 | 3.0 | 763 | — | — | — |
-| reference | export-pipeline/distribution-itch-steam.md | 3026 | 3.0 | 757 | — | — | — |
-| reference | ai-navigation/patrol-patterns.md | 2992 | 2.9 | 748 | — | — | — |
-| reference | responsive-ui/adaptive-layouts.md | 2888 | 2.8 | 722 | — | — | — |
-| reference | 3d-essentials/fog-recipes.md | 2875 | 2.8 | 719 | — | — | — |
-| reference | shader-basics/stencil-buffer.md | 2856 | 2.8 | 714 | — | — | — |
-| reference | godot-ui/focus-and-navigation.md | 2845 | 2.8 | 711 | — | — | — |
-| reference | math-essentials/random-numbers.md | 2792 | 2.7 | 698 | — | — | — |
-| reference | 2d-essentials/parallax.md | 2776 | 2.7 | 694 | — | — | — |
-| reference | gdscript-patterns/super-in-virtual-methods.md | 2771 | 2.7 | 693 | — | — | — |
-| reference | shader-basics/post-processing.md | 2735 | 2.7 | 684 | — | — | — |
-| reference | math-essentials/game-math-recipes.md | 2727 | 2.7 | 682 | — | — | — |
-| reference | dependency-injection/autoloads.md | 2649 | 2.6 | 662 | — | — | — |
-| reference | responsive-ui/pixel-art-setup.md | 2644 | 2.6 | 661 | — | — | — |
-| reference | dependency-injection/export-injection.md | 2593 | 2.5 | 648 | — | — | — |
-| reference | gdscript-patterns/common-idioms.md | 2586 | 2.5 | 647 | — | — | — |
-| reference | godot-testing/running-tests.md | 2577 | 2.5 | 644 | — | — | — |
-| reference | csharp-signals/disconnecting.md | 2560 | 2.5 | 640 | — | — | — |
-| reference | csharp-signals/awaiting-signals.md | 2550 | 2.5 | 638 | — | — | — |
-| reference | 3d-essentials/global-illumination.md | 2545 | 2.5 | 636 | — | — | — |
-| reference | physics-system/ragdoll-recipes.md | 2528 | 2.5 | 632 | — | — | — |
-| reference | xr-development/hand-tracking.md | 2519 | 2.5 | 630 | — | — | — |
-| reference | resource-pattern/editor-integration.md | 2503 | 2.4 | 626 | — | — | — |
-| reference | gdscript-advanced/profiler-recipes.md | 2497 | 2.4 | 624 | — | — | — |
-| reference | godot-ui/signals.md | 2472 | 2.4 | 618 | — | — | — |
-| reference | export-pipeline/ci-cd-github-actions.md | 2460 | 2.4 | 615 | — | — | — |
-| reference | 3d-essentials/decals.md | 2459 | 2.4 | 615 | — | — | — |
-| reference | gdscript-patterns/abstract-classes.md | 2422 | 2.4 | 606 | — | — | — |
-| reference | dependency-injection/scene-injection.md | 2402 | 2.3 | 601 | — | — | — |
-| reference | dialogue-system/variable-interpolation.md | 2386 | 2.3 | 597 | — | — | — |
-| reference | save-load/version-migration.md | 2368 | 2.3 | 592 | — | — | — |
-| reference | gdscript-advanced/tool-script-recipes.md | 2350 | 2.3 | 588 | — | — | — |
-| reference | particles-vfx/subemitters.md | 2319 | 2.3 | 580 | — | — | — |
-| reference | physics-system/area-recipes.md | 2233 | 2.2 | 558 | — | — | — |
-| reference | animation-system/sprite-animation.md | 2195 | 2.1 | 549 | — | — | — |
-| reference | gdextension/debugging-native.md | 2132 | 2.1 | 533 | — | — | — |
-| reference | resource-pattern/sharing-vs-unique.md | 2122 | 2.1 | 531 | — | — | — |
-| reference | addon-development/dock-panels.md | 2086 | 2.0 | 522 | — | — | — |
-| reference | gdscript-advanced/metaprogramming-recipes.md | 2081 | 2.0 | 520 | — | — | — |
-| reference | particles-vfx/trails.md | 2007 | 2.0 | 502 | — | — | — |
-| reference | animation-system/skeleton-modifiers.md | 2000 | 2.0 | 500 | — | — | — |
-| reference | gdextension/rust-gdext.md | 1998 | 2.0 | 500 | — | — | — |
-| reference | xr-development/xr-ui.md | 1985 | 1.9 | 496 | — | — | — |
-| reference | math-essentials/curves-and-paths.md | 1895 | 1.9 | 474 | — | — | — |
-| reference | animation-system/common-recipes.md | 1892 | 1.8 | 473 | — | — | — |
-| reference | resource-pattern/saving-resources.md | 1882 | 1.8 | 471 | — | — | — |
-| reference | physics-system/staticbody-recipes.md | 1879 | 1.8 | 470 | — | — | — |
-| reference | responsive-ui/dpi-scaling.md | 1845 | 1.8 | 461 | — | — | — |
-| reference | gdscript-patterns/export-annotations.md | 1821 | 1.8 | 455 | — | — | — |
-| reference | gdscript-patterns/variadic-functions.md | 1805 | 1.8 | 451 | — | — | — |
-| reference | particles-vfx/flipbook-animation.md | 1781 | 1.7 | 445 | — | — | — |
-| reference | csharp-signals/connecting-gdscript-signals.md | 1770 | 1.7 | 443 | — | — | — |
-| reference | tween-animation/looping-and-signals.md | 1736 | 1.7 | 434 | — | — | — |
-| reference | physics-system/interpolation-camera.md | 1734 | 1.7 | 434 | — | — | — |
-| reference | shader-basics/3d-shader-recipes.md | 1703 | 1.7 | 426 | — | — | — |
-| reference | tween-animation/property-tweener-modifiers.md | 1632 | 1.6 | 408 | — | — | — |
-| reference | tween-animation/lifecycle.md | 1569 | 1.5 | 392 | — | — | — |
-| reference | mobile-development/crash-debugging.md | 1280 | 1.3 | 320 | — | — | — |
-| reference | xr-development/passthrough.md | 1265 | 1.2 | 316 | — | — | — |
-| reference | input-handling/touch.md | 1229 | 1.2 | 307 | — | — | — |
-| reference | animation-system/retargeting.md | 838 | 0.8 | 210 | — | — | — |
-| reference | using-godot-prompter/gemini-tools.md | 742 | 0.7 | 186 | — | — | — |
-| reference | using-godot-prompter/cursor-tools.md | 734 | 0.7 | 184 | — | — | — |
-| reference | using-godot-prompter/copilot-tools.md | 712 | 0.7 | 178 | — | — | — |
-| reference | using-godot-prompter/codex-tools.md | 688 | 0.7 | 172 | — | — | — |
+| reference | ability-system/tags-and-conditions.md | 18567 | 18.1 | 4642 | 5101 | 4487 | — |
+| skill | animation-system | 16364 | 16.0 | 4091 | 4207 | 3785 | ✓ under budget |
+| skill | 3d-essentials | 16307 | 15.9 | 4077 | 4083 | 3706 | ✓ under budget |
+| skill | physics-system | 16300 | 15.9 | 4075 | 4532 | 4146 | ✓ under budget |
+| skill | ai-navigation | 16231 | 15.9 | 4058 | 4398 | 3960 | ✓ under budget |
+| skill | multiplayer-basics | 15997 | 15.6 | 3999 | 4340 | 3737 | ✓ under budget |
+| skill | event-bus | 15935 | 15.6 | 3984 | 4144 | 3542 | ✓ under budget |
+| skill | shader-basics | 15826 | 15.5 | 3957 | 4090 | 3642 | ✓ under budget |
+| skill | localization | 15649 | 15.3 | 3912 | 4308 | 3834 | ✓ under budget |
+| skill | assets-pipeline | 15592 | 15.2 | 3898 | 3828 | 3480 | ✓ under budget |
+| reference | ability-system/stat-modifiers.md | 15551 | 15.2 | 3888 | 4251 | 3742 | — |
+| skill | xr-development | 15344 | 15.0 | 3836 | 4047 | 3705 | ✓ under budget |
+| skill | gdscript-patterns | 15141 | 14.8 | 3785 | 4090 | 3710 | ✓ under budget |
+| skill | input-handling | 14955 | 14.6 | 3739 | 3906 | 3419 | ✓ under budget |
+| skill | godot-code-review | 14602 | 14.3 | 3651 | 4028 | 3566 | ✓ under budget |
+| skill | particles-vfx | 14564 | 14.2 | 3641 | 4032 | 3668 | ✓ under budget |
+| skill | state-machine | 14495 | 14.2 | 3624 | 3920 | 3384 | ✓ under budget |
+| skill | godot-brainstorming | 14097 | 13.8 | 3524 | 3718 | 3497 | ✓ under budget |
+| skill | godot-ui | 14061 | 13.7 | 3515 | 3992 | 3589 | ✓ under budget |
+| skill | component-system | 14009 | 13.7 | 3502 | 3560 | 3131 | ✓ under budget |
+| skill | export-pipeline | 14005 | 13.7 | 3501 | 3749 | 3291 | ✓ under budget |
+| skill | csharp-godot | 13944 | 13.6 | 3486 | 3952 | 3556 | ✓ under budget |
+| skill | player-controller | 13918 | 13.6 | 3480 | 3745 | 3433 | ✓ under budget |
+| skill | audio-system | 13901 | 13.6 | 3475 | 3718 | 3327 | ✓ under budget |
+| skill | inventory-system | 13872 | 13.5 | 3468 | 3313 | 2971 | ✓ under budget |
+| skill | tween-animation | 13528 | 13.2 | 3382 | 3941 | 3382 | ✓ under budget |
+| skill | addon-development | 13447 | 13.1 | 3362 | 3568 | 3158 | ✓ under budget |
+| reference | save-load/json-saves.md | 12833 | 12.5 | 3208 | 3197 | 2704 | — |
+| skill | limboai | 12827 | 12.5 | 3207 | 3804 | 3350 | ✓ under budget |
+| skill | godot-project-setup | 12817 | 12.5 | 3204 | 3724 | 3189 | ✓ under budget |
+| skill | math-essentials | 12716 | 12.4 | 3179 | 3568 | 3144 | ✓ under budget |
+| skill | resource-pattern | 12545 | 12.3 | 3136 | 3373 | 3046 | ✓ under budget |
+| skill | godot-debugging | 12259 | 12.0 | 3065 | 3140 | 2835 | ✓ under budget |
+| skill | ability-system | 12155 | 11.9 | 3039 | 3108 | 2788 | ✓ under budget |
+| skill | using-godot-prompter | 11979 | 11.7 | 2995 | 3186 | 2845 | ✓ under budget |
+| skill | godot-optimization | 11865 | 11.6 | 2966 | 3097 | 2801 | ✓ under budget |
+| skill | dedicated-server | 11715 | 11.4 | 2929 | 3000 | 2669 | ✓ under budget |
+| skill | hud-system | 11548 | 11.3 | 2887 | 3153 | 2743 | ✓ under budget |
+| skill | dependency-injection | 11334 | 11.1 | 2834 | 2860 | 2522 | ✓ under budget |
+| skill | camera-system | 11038 | 10.8 | 2760 | 3182 | 2911 | ✓ under budget |
+| skill | dialogue-system | 10898 | 10.6 | 2725 | 2552 | 2230 | ✓ under budget |
+| skill | beehave | 10871 | 10.6 | 2718 | 2921 | 2669 | ✓ under budget |
+| skill | multiplayer-sync | 10659 | 10.4 | 2665 | 2719 | 2516 | ✓ under budget |
+| skill | scene-organization | 10447 | 10.2 | 2612 | 2717 | 2433 | ✓ under budget |
+| reference | godot-optimization/memory-management.md | 10420 | 10.2 | 2605 | 2795 | 2494 | — |
+| skill | multithreading | 10367 | 10.1 | 2592 | 2809 | 2399 | ✓ under budget |
+| reference | ability-system/ui-binding.md | 10207 | 10.0 | 2552 | 2836 | 2527 | — |
+| skill | gdscript-advanced | 10075 | 9.8 | 2519 | 2766 | 2463 | ✓ under budget |
+| skill | csharp-signals | 9651 | 9.4 | 2413 | 2447 | 2225 | ✓ under budget |
+| skill | godot-testing | 9564 | 9.3 | 2391 | 2346 | 2037 | ✓ under budget |
+| reference | dedicated-server/lobby-management.md | 9121 | 8.9 | 2280 | 2387 | 2061 | — |
+| skill | gdextension | 8949 | 8.7 | 2237 | 2599 | 2201 | ✓ under budget |
+| skill | responsive-ui | 8912 | 8.7 | 2228 | 2393 | 2161 | ✓ under budget |
+| skill | 2d-essentials | 8814 | 8.6 | 2204 | 2412 | 2227 | ✓ under budget |
+| reference | addon-development/inspector-plugins.md | 8649 | 8.4 | 2162 | 2237 | 1963 | — |
+| reference | ai-navigation/chase-attack.md | 8531 | 8.3 | 2133 | 2189 | 1934 | — |
+| reference | dialogue-system/ui-presentation.md | 8498 | 8.3 | 2125 | 1943 | 1703 | — |
+| skill | mobile-development | 8192 | 8.0 | 2048 | 2246 | 1982 | ✓ under budget |
+| reference | godot-optimization/cpu-bottlenecks.md | 7642 | 7.5 | 1911 | 2116 | 1872 | — |
+| reference | godot-ui/ui-patterns.md | 7611 | 7.4 | 1903 | 2091 | 1766 | — |
+| reference | dialogue-system/dialogue-manager.md | 7540 | 7.4 | 1885 | 1944 | 1657 | — |
+| reference | procedural-generation/wave-function-collapse.md | 7334 | 7.2 | 1834 | 1954 | 1780 | — |
+| reference | inventory-system/ui-binding.md | 6873 | 6.7 | 1718 | 1821 | 1585 | — |
+| reference | godot-optimization/draw-calls.md | 6785 | 6.6 | 1696 | 1863 | 1635 | — |
+| reference | addon-development/gizmos-deep-dive.md | 6717 | 6.6 | 1679 | 2132 | 1892 | — |
+| reference | animation-system/ik-recipes.md | 6608 | 6.5 | 1652 | 2082 | 1888 | — |
+| reference | procedural-generation/bsp-dungeons.md | 6542 | 6.4 | 1636 | 2079 | 1779 | — |
+| reference | camera-system/camera3d-patterns.md | 6471 | 6.3 | 1618 | 1801 | 1636 | — |
+| reference | hud-system/damage-numbers.md | 6451 | 6.3 | 1613 | 1871 | 1658 | — |
+| reference | dedicated-server/match-flow.md | 6433 | 6.3 | 1608 | 1602 | 1404 | — |
+| reference | event-bus/testing.md | 6372 | 6.2 | 1593 | 1797 | 1520 | — |
+| reference | 3d-essentials/environment-and-post.md | 6266 | 6.1 | 1567 | 1647 | 1513 | — |
+| reference | ai-navigation/behavior-trees.md | 6266 | 6.1 | 1567 | 1774 | 1528 | — |
+| reference | ai-navigation/steering-behaviors.md | 6086 | 5.9 | 1522 | 1304 | 1166 | — |
+| reference | godot-testing/tdd-workflow.md | 5945 | 5.8 | 1486 | 1702 | 1476 | — |
+| agent | godot-tools-engineer | 5931 | 5.8 | 1483 | 1606 | 1467 | — |
+| reference | physics-system/rigidbody-recipes.md | 5891 | 5.8 | 1473 | 1719 | 1512 | — |
+| reference | tween-animation/common-recipes.md | 5726 | 5.6 | 1432 | 2013 | 1657 | — |
+| agent | godot-csharp-engineer | 5726 | 5.6 | 1432 | 1587 | 1454 | — |
+| reference | inventory-system/serialization.md | 5705 | 5.6 | 1426 | 1290 | 1114 | — |
+| reference | multiplayer-sync/client-prediction.md | 5614 | 5.5 | 1404 | 1478 | 1332 | — |
+| reference | beehave/custom-nodes.md | 5518 | 5.4 | 1380 | 1527 | 1343 | — |
+| reference | multiplayer-sync/lag-compensation.md | 5517 | 5.4 | 1379 | 1509 | 1332 | — |
+| reference | godot-debugging/signal-tracing.md | 5452 | 5.3 | 1363 | 1482 | 1232 | — |
+| reference | hud-system/interaction-prompts.md | 5451 | 5.3 | 1363 | 1482 | 1313 | — |
+| reference | input-handling/action-rebinding.md | 5369 | 5.2 | 1342 | 1415 | 1235 | — |
+| reference | audio-system/interactive-music.md | 5333 | 5.2 | 1333 | 1562 | 1327 | — |
+| agent | godot-animator | 5266 | 5.1 | 1317 | 1340 | 1246 | — |
+| reference | state-machine/hierarchical-and-parallel.md | 5241 | 5.1 | 1310 | 1401 | 1195 | — |
+| agent | godot-ui-designer | 5088 | 5.0 | 1272 | 1326 | 1217 | — |
+| reference | dedicated-server/server-config.md | 5002 | 4.9 | 1251 | 1444 | 1284 | — |
+| reference | csharp-signals/custom-signal-patterns.md | 4993 | 4.9 | 1248 | 1260 | 1126 | — |
+| skill | procedural-generation | 4975 | 4.9 | 1244 | 1357 | 1224 | ✓ under budget |
+| reference | 2d-essentials/tilemap.md | 4969 | 4.9 | 1242 | 1353 | 1210 | — |
+| reference | dependency-injection/service-locator.md | 4914 | 4.8 | 1229 | 1237 | 1079 | — |
+| reference | camera-system/transitions.md | 4886 | 4.8 | 1222 | 1365 | 1146 | — |
+| reference | dialogue-system/branching-and-conditions.md | 4871 | 4.8 | 1218 | 1394 | 1178 | — |
+| reference | particles-vfx/vfx-recipes.md | 4803 | 4.7 | 1201 | 1615 | 1544 | — |
+| reference | responsive-ui/mobile.md | 4787 | 4.7 | 1197 | 1348 | 1100 | — |
+| reference | limboai/hsm.md | 4780 | 4.7 | 1195 | 1481 | 1256 | — |
+| reference | godot-optimization/physics-tuning.md | 4754 | 4.6 | 1189 | 1369 | 1239 | — |
+| skill | save-load | 4742 | 4.6 | 1186 | 1137 | 1006 | ✓ under budget |
+| agent | godot-game-dev | 4707 | 4.6 | 1177 | 1311 | 1194 | — |
+| agent | godot-performance-profiler | 4672 | 4.6 | 1168 | 1154 | 1105 | — |
+| reference | procedural-generation/cellular-automata.md | 4655 | 4.5 | 1164 | 1340 | 1289 | — |
+| reference | godot-brainstorming/example-chest.md | 4578 | 4.5 | 1145 | 1323 | 1179 | — |
+| reference | input-handling/mouse.md | 4510 | 4.4 | 1128 | 1225 | 1033 | — |
+| reference | dialogue-system/external-formats.md | 4491 | 4.4 | 1123 | 1198 | 1030 | — |
+| reference | audio-system/sfx-pooling.md | 4469 | 4.4 | 1117 | 1347 | 1230 | — |
+| agent | godot-game-architect | 4445 | 4.3 | 1111 | 1133 | 1042 | — |
+| reference | multiplayer-sync/bandwidth-optimization.md | 4431 | 4.3 | 1108 | 1228 | 1137 | — |
+| reference | using-godot-prompter/antigravity-tools.md | 4378 | 4.3 | 1095 | 1243 | 1117 | — |
+| reference | godot-testing/testing-patterns.md | 4377 | 4.3 | 1094 | 1345 | 1142 | — |
+| reference | godot-debugging/performance-debugging.md | 4315 | 4.2 | 1079 | 1202 | 1038 | — |
+| agent | godot-shader-author | 4264 | 4.2 | 1066 | 1124 | 1038 | — |
+| reference | player-controller/common-movement-recipes.md | 4257 | 4.2 | 1064 | 1174 | 1049 | — |
+| reference | godot-debugging/systematic-method.md | 4245 | 4.1 | 1061 | 1187 | 1064 | — |
+| reference | shader-basics/compositor-effects.md | 4228 | 4.1 | 1057 | 1109 | 959 | — |
+| reference | input-handling/gamepad.md | 4218 | 4.1 | 1055 | 1226 | 1084 | — |
+| reference | inventory-system/equipment.md | 4191 | 4.1 | 1048 | 1098 | 973 | — |
+| reference | multiplayer-basics/player-join-flow.md | 4188 | 4.1 | 1047 | 1237 | 1036 | — |
+| reference | multithreading/pitfalls.md | 4182 | 4.1 | 1046 | 1069 | 967 | — |
+| reference | hud-system/notifications.md | 4179 | 4.1 | 1045 | 1197 | 1021 | — |
+| reference | save-load/save-architecture.md | 4160 | 4.1 | 1040 | 1138 | 979 | — |
+| reference | 2d-essentials/2d-particles.md | 4083 | 4.0 | 1021 | 1159 | 1068 | — |
+| reference | dedicated-server/deployment.md | 4071 | 4.0 | 1018 | 1237 | 1048 | — |
+| reference | 2d-essentials/lights-and-shadows.md | 4006 | 3.9 | 1002 | 1171 | 1068 | — |
+| reference | 3d-essentials/materials-and-lighting-recipes.md | 3959 | 3.9 | 990 | 1266 | 1099 | — |
+| reference | procedural-generation/noise-generation.md | 3958 | 3.9 | 990 | 1250 | 1161 | — |
+| reference | mobile-development/plugins.md | 3879 | 3.8 | 970 | 1093 | 962 | — |
+| reference | shader-basics/2d-shader-recipes.md | 3707 | 3.6 | 927 | 1292 | 1136 | — |
+| reference | audio-system/music-manager.md | 3649 | 3.6 | 912 | 1082 | 920 | — |
+| agent | godot-code-reviewer | 3642 | 3.6 | 911 | 1046 | 933 | — |
+| reference | audio-system/audio-settings.md | 3635 | 3.5 | 909 | 1054 | 919 | — |
+| reference | godot-ui/theme-system.md | 3601 | 3.5 | 900 | 1134 | 981 | — |
+| reference | dependency-injection/testing-with-di.md | 3558 | 3.5 | 890 | 1016 | 894 | — |
+| reference | hud-system/minimap.md | 3528 | 3.4 | 882 | 1029 | 929 | — |
+| reference | camera-system/camera-zones.md | 3506 | 3.4 | 877 | 1062 | 919 | — |
+| reference | physics-system/raycasting-recipes.md | 3493 | 3.4 | 873 | 980 | 884 | — |
+| reference | resource-pattern/configuration-pattern.md | 3481 | 3.4 | 870 | 1043 | 974 | — |
+| reference | save-load/configfile.md | 3445 | 3.4 | 861 | 1023 | 845 | — |
+| reference | 3d-essentials/lod-and-culling.md | 3404 | 3.3 | 851 | 1076 | 938 | — |
+| reference | physics-system/softbody-recipes.md | 3376 | 3.3 | 844 | 912 | 822 | — |
+| reference | resource-pattern/collections.md | 3375 | 3.3 | 844 | 892 | 763 | — |
+| reference | particles-vfx/attractors-and-collision.md | 3346 | 3.3 | 837 | 985 | 903 | — |
+| reference | xr-development/controllers-and-input.md | 3293 | 3.2 | 823 | 932 | 821 | — |
+| reference | camera-system/split-screen.md | 3253 | 3.2 | 813 | 929 | 812 | — |
+| reference | godot-debugging/scene-tree-debugging.md | 3218 | 3.1 | 805 | 901 | 784 | — |
+| reference | multiplayer-basics/disconnect-handling.md | 3212 | 3.1 | 803 | 887 | 738 | — |
+| reference | animation-system/bone-constraints.md | 3207 | 3.1 | 802 | 910 | 819 | — |
+| reference | xr-development/grabbing-objects.md | 3182 | 3.1 | 796 | 856 | 763 | — |
+| reference | multiplayer-sync/interpolation.md | 3169 | 3.1 | 792 | 834 | 758 | — |
+| reference | multiplayer-basics/spawning-networked-objects.md | 3144 | 3.1 | 786 | 910 | 755 | — |
+| reference | 2d-essentials/custom-drawing.md | 3119 | 3.0 | 780 | 971 | 868 | — |
+| reference | mobile-development/iap-and-ads.md | 3050 | 3.0 | 763 | 825 | 686 | — |
+| reference | export-pipeline/distribution-itch-steam.md | 3026 | 3.0 | 757 | 890 | 777 | — |
+| reference | ai-navigation/patrol-patterns.md | 2992 | 2.9 | 748 | 877 | 754 | — |
+| reference | responsive-ui/adaptive-layouts.md | 2888 | 2.8 | 722 | 828 | 724 | — |
+| reference | 3d-essentials/fog-recipes.md | 2875 | 2.8 | 719 | 1036 | 935 | — |
+| reference | shader-basics/stencil-buffer.md | 2856 | 2.8 | 714 | 823 | 728 | — |
+| reference | godot-ui/focus-and-navigation.md | 2845 | 2.8 | 711 | 829 | 683 | — |
+| reference | math-essentials/random-numbers.md | 2792 | 2.7 | 698 | 881 | 826 | — |
+| reference | 2d-essentials/parallax.md | 2776 | 2.7 | 694 | 851 | 776 | — |
+| reference | gdscript-patterns/super-in-virtual-methods.md | 2771 | 2.7 | 693 | 748 | 670 | — |
+| reference | shader-basics/post-processing.md | 2735 | 2.7 | 684 | 903 | 835 | — |
+| reference | math-essentials/game-math-recipes.md | 2727 | 2.7 | 682 | 849 | 707 | — |
+| reference | dependency-injection/autoloads.md | 2649 | 2.6 | 662 | 707 | 630 | — |
+| reference | responsive-ui/pixel-art-setup.md | 2644 | 2.6 | 661 | 758 | 634 | — |
+| reference | dependency-injection/export-injection.md | 2593 | 2.5 | 648 | 687 | 613 | — |
+| reference | gdscript-patterns/common-idioms.md | 2586 | 2.5 | 647 | 760 | 669 | — |
+| reference | godot-testing/running-tests.md | 2577 | 2.5 | 644 | 810 | 775 | — |
+| reference | csharp-signals/disconnecting.md | 2560 | 2.5 | 640 | 651 | 591 | — |
+| reference | csharp-signals/awaiting-signals.md | 2550 | 2.5 | 638 | 698 | 586 | — |
+| reference | 3d-essentials/global-illumination.md | 2545 | 2.5 | 636 | 756 | 679 | — |
+| reference | physics-system/ragdoll-recipes.md | 2528 | 2.5 | 632 | 732 | 647 | — |
+| reference | xr-development/hand-tracking.md | 2519 | 2.5 | 630 | 671 | 583 | — |
+| reference | resource-pattern/editor-integration.md | 2503 | 2.4 | 626 | 763 | 702 | — |
+| reference | gdscript-advanced/profiler-recipes.md | 2497 | 2.4 | 624 | 828 | 703 | — |
+| reference | godot-ui/signals.md | 2472 | 2.4 | 618 | 762 | 661 | — |
+| reference | export-pipeline/ci-cd-github-actions.md | 2460 | 2.4 | 615 | 675 | 628 | — |
+| reference | 3d-essentials/decals.md | 2459 | 2.4 | 615 | 763 | 679 | — |
+| reference | gdscript-patterns/abstract-classes.md | 2422 | 2.4 | 606 | 634 | 564 | — |
+| reference | dependency-injection/scene-injection.md | 2402 | 2.3 | 601 | 615 | 563 | — |
+| reference | dialogue-system/variable-interpolation.md | 2386 | 2.3 | 597 | 643 | 547 | — |
+| reference | save-load/version-migration.md | 2368 | 2.3 | 592 | 604 | 568 | — |
+| reference | gdscript-advanced/tool-script-recipes.md | 2350 | 2.3 | 588 | 686 | 607 | — |
+| reference | particles-vfx/subemitters.md | 2319 | 2.3 | 580 | 614 | 532 | — |
+| reference | physics-system/area-recipes.md | 2233 | 2.2 | 558 | 670 | 568 | — |
+| reference | animation-system/sprite-animation.md | 2195 | 2.1 | 549 | 573 | 509 | — |
+| reference | gdextension/debugging-native.md | 2132 | 2.1 | 533 | 559 | 497 | — |
+| reference | resource-pattern/sharing-vs-unique.md | 2122 | 2.1 | 531 | 540 | 492 | — |
+| reference | addon-development/dock-panels.md | 2086 | 2.0 | 522 | 663 | 560 | — |
+| reference | gdscript-advanced/metaprogramming-recipes.md | 2081 | 2.0 | 520 | 628 | 521 | — |
+| reference | particles-vfx/trails.md | 2007 | 2.0 | 502 | 539 | 471 | — |
+| reference | animation-system/skeleton-modifiers.md | 2000 | 2.0 | 500 | 604 | 535 | — |
+| reference | gdextension/rust-gdext.md | 1998 | 2.0 | 500 | 648 | 559 | — |
+| reference | xr-development/xr-ui.md | 1985 | 1.9 | 496 | 566 | 480 | — |
+| reference | math-essentials/curves-and-paths.md | 1895 | 1.9 | 474 | 599 | 533 | — |
+| reference | animation-system/common-recipes.md | 1892 | 1.8 | 473 | 582 | 510 | — |
+| reference | resource-pattern/saving-resources.md | 1882 | 1.8 | 471 | 522 | 460 | — |
+| reference | physics-system/staticbody-recipes.md | 1879 | 1.8 | 470 | 549 | 484 | — |
+| reference | responsive-ui/dpi-scaling.md | 1845 | 1.8 | 461 | 584 | 520 | — |
+| reference | gdscript-patterns/export-annotations.md | 1821 | 1.8 | 455 | 588 | 540 | — |
+| reference | gdscript-patterns/variadic-functions.md | 1805 | 1.8 | 451 | 514 | 477 | — |
+| reference | particles-vfx/flipbook-animation.md | 1781 | 1.7 | 445 | 499 | 469 | — |
+| reference | csharp-signals/connecting-gdscript-signals.md | 1770 | 1.7 | 443 | 481 | 407 | — |
+| reference | tween-animation/looping-and-signals.md | 1736 | 1.7 | 434 | 580 | 488 | — |
+| reference | physics-system/interpolation-camera.md | 1734 | 1.7 | 434 | 484 | 428 | — |
+| reference | shader-basics/3d-shader-recipes.md | 1703 | 1.7 | 426 | 629 | 554 | — |
+| reference | tween-animation/property-tweener-modifiers.md | 1632 | 1.6 | 408 | 591 | 510 | — |
+| reference | tween-animation/lifecycle.md | 1569 | 1.5 | 392 | 552 | 421 | — |
+| reference | mobile-development/crash-debugging.md | 1280 | 1.3 | 320 | 342 | 306 | — |
+| reference | xr-development/passthrough.md | 1265 | 1.2 | 316 | 349 | 298 | — |
+| reference | input-handling/touch.md | 1229 | 1.2 | 307 | 317 | 279 | — |
+| reference | animation-system/retargeting.md | 838 | 0.8 | 210 | 228 | 208 | — |
+| reference | using-godot-prompter/gemini-tools.md | 742 | 0.7 | 186 | 232 | 206 | — |
+| reference | using-godot-prompter/cursor-tools.md | 734 | 0.7 | 184 | 216 | 191 | — |
+| reference | using-godot-prompter/copilot-tools.md | 712 | 0.7 | 178 | 226 | 209 | — |
+| reference | using-godot-prompter/codex-tools.md | 688 | 0.7 | 172 | 199 | 178 | — |
 <!-- END-TOKEN-TABLE -->
 
 ## How to read this

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-prompter",
   "description": "Agentic skills framework for Godot 4.x — 48 domain-specific skills for GDScript and C#",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "contextFileName": "GEMINI.md"
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-prompter",
-  "description": "Agentic skills framework for Godot 4.x — 48 domain-specific skills for GDScript and C#",
+  "description": "Agentic skills framework for Godot 4.x — 51 domain-specific skills for GDScript and C#",
   "version": "1.10.0",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godot-prompter",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "type": "module",
   "main": ".opencode/plugins/godot-prompter.js",
   "description": "Agentic skills framework for Godot 4.x game development — GDScript & C#",

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -19,7 +19,8 @@ const TOKEN_BUDGET_BYTES = 16 * 1024;
 // Skills that are intentionally GDScript-only by design. Their sections still emit
 // a `csharp-parity-accepted` warning (so the count is visible) but do NOT count as
 // deferred parity debt.
-const GDSCRIPT_ONLY_BY_DESIGN = new Set(['gdscript-patterns', 'gdscript-advanced']);
+// 'beehave' is a GDScript-only addon (no official C# API), so its sections are accepted, not debt.
+const GDSCRIPT_ONLY_BY_DESIGN = new Set(['gdscript-patterns', 'gdscript-advanced', 'beehave']);
 
 const errors = [];
 const warnings = [];

--- a/skills/ability-system/SKILL.md
+++ b/skills/ability-system/SKILL.md
@@ -88,11 +88,11 @@ func try_activate(ability_name: String) -> bool:
     if resource_pool < ability.cost:
         ability_failed.emit(ability, "insufficient_resource")
         return false
-    if not ability.can_activate(owner):
+    if not ability.can_activate(get_parent()):
         ability_failed.emit(ability, "conditions_unmet")
         return false
     resource_pool -= ability.cost
-    ability.activate(owner)
+    ability.activate(get_parent())
     _cooldowns[ability_name] = ability.cooldown
     cooldown_started.emit(ability, ability.cooldown)
     ability_activated.emit(ability)
@@ -164,13 +164,13 @@ public partial class AbilityComponent : Node
             EmitSignal(SignalName.AbilityFailed, ability, "insufficient_resource");
             return false;
         }
-        if (!ability.CanActivate(Owner))
+        if (!ability.CanActivate(GetParent()))
         {
             EmitSignal(SignalName.AbilityFailed, ability, "conditions_unmet");
             return false;
         }
         ResourcePool -= ability.Cost;
-        ability.Activate(Owner);
+        ability.Activate(GetParent());
         _cooldowns[abilityName] = ability.Cooldown;
         EmitSignal(SignalName.CooldownStarted, ability, ability.Cooldown);
         EmitSignal(SignalName.AbilityActivated, ability);
@@ -213,9 +213,13 @@ signal effect_expired(effect: Effect)
 var _active: Dictionary = {}
 
 func apply_effect(effect: Effect) -> void:
-    _active[effect] = [0.0, 0.0]
-    effect.on_apply(owner)
+    effect.on_apply(get_parent())
     effect_applied.emit(effect)
+    if effect.duration <= 0.0:
+        effect.on_expire(get_parent())
+        effect_expired.emit(effect)
+        return
+    _active[effect] = [0.0, 0.0]
 
 func _process(delta: float) -> void:
     var to_remove: Array = []
@@ -225,12 +229,12 @@ func _process(delta: float) -> void:
             _active[effect][1] += delta
             if _active[effect][1] >= effect.tick_interval:
                 _active[effect][1] -= effect.tick_interval
-                effect.on_tick(owner)
+                effect.on_tick(get_parent())
         if effect.duration > 0.0 and _active[effect][0] >= effect.duration:
             to_remove.append(effect)
     for effect in to_remove:
         _active.erase(effect)
-        effect.on_expire(owner)
+        effect.on_expire(get_parent())
         effect_expired.emit(effect)
 ```
 
@@ -267,9 +271,15 @@ public partial class EffectHolder : Node
 
     public void ApplyEffect(Effect effect)
     {
-        _active[effect] = (0f, 0f);
-        effect.OnApply(Owner);
+        effect.OnApply(GetParent());
         EmitSignal(SignalName.EffectApplied, effect);
+        if (effect.Duration <= 0f)
+        {
+            effect.OnExpire(GetParent());
+            EmitSignal(SignalName.EffectExpired, effect);
+            return;
+        }
+        _active[effect] = (0f, 0f);
     }
 
     public override void _Process(double delta)
@@ -285,18 +295,18 @@ public partial class EffectHolder : Node
                 if (tickAccum >= effect.TickInterval)
                 {
                     tickAccum -= effect.TickInterval;
-                    effect.OnTick(Owner);
+                    effect.OnTick(GetParent());
                 }
             }
             if (effect.Duration > 0f && elapsed >= effect.Duration)
                 toRemove.Add(effect);
             else
-                _active[effect] = (elapsed, tickAccum);
+                _active[effect] = (elapsed, tickAccum); // expiring — no need to write back
         }
         foreach (var effect in toRemove)
         {
             _active.Remove(effect);
-            effect.OnExpire(Owner);
+            effect.OnExpire(GetParent());
             EmitSignal(SignalName.EffectExpired, effect);
         }
     }

--- a/skills/ability-system/SKILL.md
+++ b/skills/ability-system/SKILL.md
@@ -30,6 +30,155 @@ This separation means an `Ability` resource carries no Node references and can b
 
 ---
 
+## 2. Abilities (cost / cooldown / cast)
+
+### GDScript
+
+```gdscript
+# ability.gd
+class_name Ability
+extends Resource
+
+@export var ability_name: String
+@export var cost: float = 0.0
+@export var cooldown: float = 1.0
+@export var cast_time: float = 0.0
+
+# Override in subclasses or compose via exported effect resources.
+func can_activate(caster: Node) -> bool:
+    return true
+
+func activate(caster: Node) -> void:
+    pass
+```
+
+```gdscript
+# ability_component.gd
+class_name AbilityComponent
+extends Node
+
+signal ability_activated(ability: Ability)
+signal ability_failed(ability: Ability, reason: String)
+signal cooldown_started(ability: Ability, duration: float)
+signal cooldown_finished(ability: Ability)
+
+@export var resource_pool: float = 100.0
+
+var _granted: Dictionary = {}        # ability_name -> Ability
+var _cooldowns: Dictionary = {}      # ability_name -> seconds remaining
+
+func grant(ability: Ability) -> void:
+    _granted[ability.ability_name] = ability
+
+func _process(delta: float) -> void:
+    for name in _cooldowns.keys():
+        _cooldowns[name] -= delta
+        if _cooldowns[name] <= 0.0:
+            _cooldowns.erase(name)
+            cooldown_finished.emit(_granted[name])
+
+func try_activate(ability_name: String) -> bool:
+    var ability: Ability = _granted.get(ability_name)
+    if ability == null:
+        return false
+    if _cooldowns.has(ability_name):
+        ability_failed.emit(ability, "on_cooldown")
+        return false
+    if resource_pool < ability.cost:
+        ability_failed.emit(ability, "insufficient_resource")
+        return false
+    if not ability.can_activate(owner):
+        ability_failed.emit(ability, "conditions_unmet")
+        return false
+    resource_pool -= ability.cost
+    ability.activate(owner)
+    _cooldowns[ability_name] = ability.cooldown
+    cooldown_started.emit(ability, ability.cooldown)
+    ability_activated.emit(ability)
+    return true
+```
+
+### C#
+
+```csharp
+// Ability.cs
+using Godot;
+
+[GlobalClass]
+public partial class Ability : Resource
+{
+    [Export] public string AbilityName { get; set; } = "";
+    [Export] public float Cost { get; set; } = 0.0f;
+    [Export] public float Cooldown { get; set; } = 1.0f;
+    [Export] public float CastTime { get; set; } = 0.0f;
+
+    public virtual bool CanActivate(Node caster) => true;
+    public virtual void Activate(Node caster) { }
+}
+```
+
+```csharp
+// AbilityComponent.cs
+using Godot;
+using System.Collections.Generic;
+
+public partial class AbilityComponent : Node
+{
+    [Signal] public delegate void AbilityActivatedEventHandler(Ability ability);
+    [Signal] public delegate void AbilityFailedEventHandler(Ability ability, string reason);
+    [Signal] public delegate void CooldownStartedEventHandler(Ability ability, float duration);
+    [Signal] public delegate void CooldownFinishedEventHandler(Ability ability);
+
+    [Export] public float ResourcePool { get; set; } = 100.0f;
+
+    private readonly Dictionary<string, Ability> _granted = new();
+    private readonly Dictionary<string, float> _cooldowns = new();
+
+    public void Grant(Ability ability) => _granted[ability.AbilityName] = ability;
+
+    public override void _Process(double delta)
+    {
+        foreach (var name in new List<string>(_cooldowns.Keys))
+        {
+            _cooldowns[name] -= (float)delta;
+            if (_cooldowns[name] <= 0.0f)
+            {
+                _cooldowns.Remove(name);
+                EmitSignal(SignalName.CooldownFinished, _granted[name]);
+            }
+        }
+    }
+
+    public bool TryActivate(string abilityName)
+    {
+        if (!_granted.TryGetValue(abilityName, out var ability)) return false;
+        if (_cooldowns.ContainsKey(abilityName))
+        {
+            EmitSignal(SignalName.AbilityFailed, ability, "on_cooldown");
+            return false;
+        }
+        if (ResourcePool < ability.Cost)
+        {
+            EmitSignal(SignalName.AbilityFailed, ability, "insufficient_resource");
+            return false;
+        }
+        if (!ability.CanActivate(Owner))
+        {
+            EmitSignal(SignalName.AbilityFailed, ability, "conditions_unmet");
+            return false;
+        }
+        ResourcePool -= ability.Cost;
+        ability.Activate(Owner);
+        _cooldowns[abilityName] = ability.Cooldown;
+        EmitSignal(SignalName.CooldownStarted, ability, ability.Cooldown);
+        EmitSignal(SignalName.AbilityActivated, ability);
+        return true;
+    }
+}
+```
+
+---
+
 ## Implementation Checklist
 
 - [ ] `Ability` resource defined with `ability_name`, `cost`, `cooldown`, `cast_time`, `can_activate`, and `activate`

--- a/skills/ability-system/SKILL.md
+++ b/skills/ability-system/SKILL.md
@@ -9,6 +9,8 @@ Build a data-driven ability system from Godot-native parts: abilities are `Resou
 
 > **Related skills:** **resource-pattern** for the `Resource` data containers, **component-system** for the component node pattern, **event-bus** for cross-system ability events, **state-machine** for caster states (e.g. casting/stunned), **hud-system** for cooldown UI.
 
+---
+
 ## 1. Architecture overview
 
 An ability system in Godot 4.x is built from three collaborating layers:

--- a/skills/ability-system/SKILL.md
+++ b/skills/ability-system/SKILL.md
@@ -301,7 +301,7 @@ public partial class EffectHolder : Node
             if (effect.Duration > 0f && elapsed >= effect.Duration)
                 toRemove.Add(effect);
             else
-                _active[effect] = (elapsed, tickAccum); // expiring — no need to write back
+                _active[effect] = (elapsed, tickAccum); // still active — write back updated elapsed and tick accumulator
         }
         foreach (var effect in toRemove)
         {

--- a/skills/ability-system/SKILL.md
+++ b/skills/ability-system/SKILL.md
@@ -181,6 +181,132 @@ public partial class AbilityComponent : Node
 
 ---
 
+## 3. Buffs & debuffs (timed effects)
+
+Effects are `Resource` subclasses — designers create them in the editor and abilities apply them. An `EffectHolder` node owns the runtime: it tracks elapsed time, calls periodic ticks, and removes effects when they expire.
+
+### GDScript
+
+```gdscript
+# effect.gd
+class_name Effect
+extends Resource
+
+@export var effect_name: String
+@export var duration: float = 5.0       # seconds; <= 0 means instant
+@export var tick_interval: float = 0.0  # 0 = no periodic tick
+
+func on_apply(target: Node) -> void: pass
+func on_tick(target: Node) -> void: pass
+func on_expire(target: Node) -> void: pass
+```
+
+```gdscript
+# effect_holder.gd
+class_name EffectHolder
+extends Node
+
+signal effect_applied(effect: Effect)
+signal effect_expired(effect: Effect)
+
+# effect -> [elapsed, tick_accum]
+var _active: Dictionary = {}
+
+func apply_effect(effect: Effect) -> void:
+    _active[effect] = [0.0, 0.0]
+    effect.on_apply(owner)
+    effect_applied.emit(effect)
+
+func _process(delta: float) -> void:
+    var to_remove: Array = []
+    for effect in _active:
+        _active[effect][0] += delta
+        if effect.tick_interval > 0.0:
+            _active[effect][1] += delta
+            if _active[effect][1] >= effect.tick_interval:
+                _active[effect][1] -= effect.tick_interval
+                effect.on_tick(owner)
+        if effect.duration > 0.0 and _active[effect][0] >= effect.duration:
+            to_remove.append(effect)
+    for effect in to_remove:
+        _active.erase(effect)
+        effect.on_expire(owner)
+        effect_expired.emit(effect)
+```
+
+### C#
+
+```csharp
+// Effect.cs
+using Godot;
+
+[GlobalClass]
+public partial class Effect : Resource
+{
+    [Export] public string EffectName { get; set; } = "";
+    [Export] public float Duration { get; set; } = 5.0f;     // <= 0 = instant
+    [Export] public float TickInterval { get; set; } = 0.0f; // 0 = no tick
+
+    public virtual void OnApply(Node target) { }
+    public virtual void OnTick(Node target) { }
+    public virtual void OnExpire(Node target) { }
+}
+```
+
+```csharp
+// EffectHolder.cs
+using Godot;
+using System.Collections.Generic;
+
+public partial class EffectHolder : Node
+{
+    [Signal] public delegate void EffectAppliedEventHandler(Effect effect);
+    [Signal] public delegate void EffectExpiredEventHandler(Effect effect);
+
+    private readonly Dictionary<Effect, (float Elapsed, float TickAccum)> _active = new();
+
+    public void ApplyEffect(Effect effect)
+    {
+        _active[effect] = (0f, 0f);
+        effect.OnApply(Owner);
+        EmitSignal(SignalName.EffectApplied, effect);
+    }
+
+    public override void _Process(double delta)
+    {
+        var toRemove = new List<Effect>();
+        foreach (var effect in new List<Effect>(_active.Keys))
+        {
+            var (elapsed, tickAccum) = _active[effect];
+            elapsed += (float)delta;
+            if (effect.TickInterval > 0f)
+            {
+                tickAccum += (float)delta;
+                if (tickAccum >= effect.TickInterval)
+                {
+                    tickAccum -= effect.TickInterval;
+                    effect.OnTick(Owner);
+                }
+            }
+            if (effect.Duration > 0f && elapsed >= effect.Duration)
+                toRemove.Add(effect);
+            else
+                _active[effect] = (elapsed, tickAccum);
+        }
+        foreach (var effect in toRemove)
+        {
+            _active.Remove(effect);
+            effect.OnExpire(Owner);
+            EmitSignal(SignalName.EffectExpired, effect);
+        }
+    }
+}
+```
+
+> **Footgun:** Never iterate `_active` directly while removing entries. GDScript builds a `to_remove` list and erases after the loop; C# iterates `new List<Effect>(_active.Keys)` for the same reason.
+
+---
+
 ## Implementation Checklist
 
 - [ ] `Ability` resource defined with `ability_name`, `cost`, `cooldown`, `cast_time`, `can_activate`, and `activate`
@@ -189,3 +315,6 @@ public partial class AbilityComponent : Node
 - [ ] Stat modifiers applied through `StatSet` (see [references/stat-modifiers.md](references/stat-modifiers.md))
 - [ ] Gameplay tags gating activation via `GameplayTagContainer` (see [references/tags-and-conditions.md](references/tags-and-conditions.md))
 - [ ] Cooldown bars and resource meters bound to `AbilityComponent` signals (see [references/ui-binding.md](references/ui-binding.md))
+- [ ] `Effect` resource subclassed with `on_apply`/`on_tick`/`on_expire` overrides; `duration` and `tick_interval` exported
+- [ ] `EffectHolder` node added to entity; `apply_effect(effect)` called from ability `activate()`
+- [ ] Effect iteration uses a copy / removal list to avoid mutating `_active` mid-loop

--- a/skills/ability-system/SKILL.md
+++ b/skills/ability-system/SKILL.md
@@ -9,8 +9,6 @@ Build a data-driven ability system from Godot-native parts: abilities are `Resou
 
 > **Related skills:** **resource-pattern** for the `Resource` data containers, **component-system** for the component node pattern, **event-bus** for cross-system ability events, **state-machine** for caster states (e.g. casting/stunned), **hud-system** for cooldown UI.
 
----
-
 ## 1. Architecture overview
 
 An ability system in Godot 4.x is built from three collaborating layers:
@@ -317,14 +315,12 @@ public partial class EffectHolder : Node
 
 ---
 
-## Implementation Checklist
+## Implementation checklist
 
-- [ ] `Ability` resource defined with `ability_name`, `cost`, `cooldown`, `cast_time`, `can_activate`, and `activate`
-- [ ] `AbilityComponent` node added to entity; signals connected to UI and game logic
-- [ ] Abilities granted via `grant(ability)` and triggered via `try_activate(ability_name)`
-- [ ] Stat modifiers applied through `StatSet` (see [references/stat-modifiers.md](references/stat-modifiers.md))
-- [ ] Gameplay tags gating activation via `GameplayTagContainer` (see [references/tags-and-conditions.md](references/tags-and-conditions.md))
-- [ ] Cooldown bars and resource meters bound to `AbilityComponent` signals (see [references/ui-binding.md](references/ui-binding.md))
-- [ ] `Effect` resource subclassed with `on_apply`/`on_tick`/`on_expire` overrides; `duration` and `tick_interval` exported
-- [ ] `EffectHolder` node added to entity; `apply_effect(effect)` called from ability `activate()`
-- [ ] Effect iteration uses a copy / removal list to avoid mutating `_active` mid-loop
+- [ ] Abilities are `Resource`s; behavior lives in `AbilityComponent`, not in the data.
+- [ ] Activation validates cost, cooldown, and `can_activate()` before spending resources.
+- [ ] Cooldowns tick in `_process`/`_Process` and emit start/finish signals.
+- [ ] Buffs/debuffs apply → tick → expire and emit signals; durations refresh or stack by source.
+- [ ] Stat modifiers recompute deterministically (ADD → MULTIPLY → OVERRIDE) and clamp.
+- [ ] Ability gating uses the gameplay-tag container; immunities block effects.
+- [ ] HUD binds to component signals — no per-frame polling of cooldown state.

--- a/skills/ability-system/SKILL.md
+++ b/skills/ability-system/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: ability-system
+description: Use when building character abilities — Resource-based abilities with cost/cooldown/cast, buffs/debuffs, stat modifiers, gameplay tags, and HUD binding
+---
+
+# Ability System
+
+Build a data-driven ability system from Godot-native parts: abilities are `Resource`s, an `AbilityComponent` node owns and runs them, and effects/stats/tags compose on top. No third-party addon required.
+
+> **Related skills:** **resource-pattern** for the `Resource` data containers, **component-system** for the component node pattern, **event-bus** for cross-system ability events, **state-machine** for caster states (e.g. casting/stunned), **hud-system** for cooldown UI.
+
+---
+
+## 1. Architecture overview
+
+An ability system in Godot 4.x is built from three collaborating layers:
+
+- **Data layer — `Ability` (Resource):** Each ability is a `Resource` subclass with exported fields (`ability_name`, `cost`, `cooldown`, `cast_time`) and two methods: `can_activate(caster) -> bool` to validate preconditions, and `activate(caster) -> void` to execute the effect. Storing abilities as Resources lets designers create and balance them in the Godot editor without touching code.
+
+- **Behaviour layer — `AbilityComponent` (Node):** A single node added to any entity that should use abilities. It holds the granted ability set, enforces cost/cooldown, and drives the `Ability.activate()` call. Four signals keep the rest of the game informed without coupling: `ability_activated(ability)`, `ability_failed(ability, reason)`, `cooldown_started(ability, duration)`, and `cooldown_finished(ability)`. Grant new abilities at runtime with `grant(ability)` and trigger them with `try_activate(ability_name)`.
+
+- **Effects layer — stat modifiers, buffs/debuffs, and gameplay tags:** Abilities can read from and write to a caster's `StatSet` (a Resource that owns a dictionary of named `StatModifier` entries) to apply temporary or permanent stat changes. A `GameplayTagContainer` attached to the caster gates activation — for example, a "stunned" tag can prevent any ability from firing. These three deep-dives are covered in the reference documents:
+  - [Stat modifiers and StatSet](references/stat-modifiers.md)
+  - [Gameplay tags and conditions](references/tags-and-conditions.md)
+  - [HUD binding for cooldowns and resource bars](references/ui-binding.md)
+
+**Core rule:** *Data in Resources, behavior in the component, communication via signals.*
+
+This separation means an `Ability` resource carries no Node references and can be safely duplicated, saved, and loaded as any other Godot Resource. The `AbilityComponent` owns runtime state (cooldown timers, active ability set), keeping `Ability` resources stateless and reusable across multiple casters simultaneously.
+
+---
+
+## Implementation Checklist
+
+- [ ] `Ability` resource defined with `ability_name`, `cost`, `cooldown`, `cast_time`, `can_activate`, and `activate`
+- [ ] `AbilityComponent` node added to entity; signals connected to UI and game logic
+- [ ] Abilities granted via `grant(ability)` and triggered via `try_activate(ability_name)`
+- [ ] Stat modifiers applied through `StatSet` (see [references/stat-modifiers.md](references/stat-modifiers.md))
+- [ ] Gameplay tags gating activation via `GameplayTagContainer` (see [references/tags-and-conditions.md](references/tags-and-conditions.md))
+- [ ] Cooldown bars and resource meters bound to `AbilityComponent` signals (see [references/ui-binding.md](references/ui-binding.md))

--- a/skills/ability-system/SKILL.md
+++ b/skills/ability-system/SKILL.md
@@ -75,7 +75,8 @@ func _process(delta: float) -> void:
         _cooldowns[name] -= delta
         if _cooldowns[name] <= 0.0:
             _cooldowns.erase(name)
-            cooldown_finished.emit(_granted[name])
+            if _granted.has(name):
+                cooldown_finished.emit(_granted[name])
 
 func try_activate(ability_name: String) -> bool:
     var ability: Ability = _granted.get(ability_name)
@@ -144,7 +145,8 @@ public partial class AbilityComponent : Node
             if (_cooldowns[name] <= 0.0f)
             {
                 _cooldowns.Remove(name);
-                EmitSignal(SignalName.CooldownFinished, _granted[name]);
+                if (_granted.TryGetValue(name, out var finished))
+                    EmitSignal(SignalName.CooldownFinished, finished);
             }
         }
     }

--- a/skills/ability-system/SKILL.md
+++ b/skills/ability-system/SKILL.md
@@ -19,7 +19,7 @@ An ability system in Godot 4.x is built from three collaborating layers:
 
 - **Behaviour layer — `AbilityComponent` (Node):** A single node added to any entity that should use abilities. It holds the granted ability set, enforces cost/cooldown, and drives the `Ability.activate()` call. Four signals keep the rest of the game informed without coupling: `ability_activated(ability)`, `ability_failed(ability, reason)`, `cooldown_started(ability, duration)`, and `cooldown_finished(ability)`. Grant new abilities at runtime with `grant(ability)` and trigger them with `try_activate(ability_name)`.
 
-- **Effects layer — stat modifiers, buffs/debuffs, and gameplay tags:** Abilities can read from and write to a caster's `StatSet` (a Resource that owns a dictionary of named `StatModifier` entries) to apply temporary or permanent stat changes. A `GameplayTagContainer` attached to the caster gates activation — for example, a "stunned" tag can prevent any ability from firing. These three deep-dives are covered in the reference documents:
+- **Effects layer — stat modifiers, buffs/debuffs, and gameplay tags:** Abilities can read from and write to a caster's `StatSet` (a Resource that owns a dictionary of named `StatModifier` entries) to apply temporary or permanent stat changes. A `GameplayTagContainer` node (a child of the caster) gates activation — for example, a "stunned" tag can prevent any ability from firing. These three deep-dives are covered in the reference documents:
   - [Stat modifiers and StatSet](references/stat-modifiers.md)
   - [Gameplay tags and conditions](references/tags-and-conditions.md)
   - [HUD binding for cooldowns and resource bars](references/ui-binding.md)

--- a/skills/ability-system/references/stat-modifiers.md
+++ b/skills/ability-system/references/stat-modifiers.md
@@ -51,7 +51,7 @@ using Godot;
 [GlobalClass]
 public partial class StatModifier : Resource
 {
-    public enum Operation
+    public enum ModOp
     {
         Add,       // final += Value
         Multiply,  // final *= (1.0f + Value)  — e.g. Value = 0.2f means +20%
@@ -59,7 +59,7 @@ public partial class StatModifier : Resource
     }
 
     [Export] public string StatName  { get; set; } = "";
-    [Export("operation")] public Operation Op { get; set; } = Operation.Add; // serialized as 'operation' to match the GDScript resource
+    [Export] public ModOp Operation  { get; set; } = ModOp.Add; // property name 'Operation' serializes as 'operation', matching the GDScript field
     [Export] public float Value      { get; set; } = 0.0f;
     [Export] public StringName Source { get; set; } = new StringName("");
 }
@@ -259,13 +259,13 @@ public partial class StatSet : Resource
         float running = baseVal;
         if (bySource != null)
             foreach (var mod in bySource.Values)
-                if (mod.Op == StatModifier.Operation.Add)
+                if (mod.Operation == StatModifier.ModOp.Add)
                     running += mod.Value;
 
         // --- Pass 2: MULTIPLY ---
         if (bySource != null)
             foreach (var mod in bySource.Values)
-                if (mod.Op == StatModifier.Operation.Multiply)
+                if (mod.Operation == StatModifier.ModOp.Multiply)
                     running *= (1.0f + mod.Value);
 
         // --- Pass 3: OVERRIDE (highest value wins) ---
@@ -274,7 +274,7 @@ public partial class StatSet : Resource
             float overrideVal  = float.NegativeInfinity;
             bool  hasOverride  = false;
             foreach (var mod in bySource.Values)
-                if (mod.Op == StatModifier.Operation.Override && mod.Value >= overrideVal)
+                if (mod.Operation == StatModifier.ModOp.Override && mod.Value >= overrideVal)
                 {
                     overrideVal = mod.Value;
                     hasOverride = true;
@@ -344,7 +344,7 @@ stat_set.add_modifier(boots_mod)
 // Refresh: re-applying "sprint" replaces the old entry.
 var sprintMod = new StatModifier {
     StatName  = "speed",
-    Op        = StatModifier.Operation.Add,
+    Operation = StatModifier.ModOp.Add,
     Value     = 100f,
     Source    = new StringName("ability:sprint"),
 };
@@ -354,7 +354,7 @@ statSet.AddModifier(sprintMod);  // refresh — one modifier, not two
 // Stack: boots and sprint are separate sources.
 var bootsMod = new StatModifier {
     StatName  = "speed",
-    Op        = StatModifier.Operation.Add,
+    Operation = StatModifier.ModOp.Add,
     Value     = 50f,
     Source    = new StringName("item:boots_of_speed"),
 };

--- a/skills/ability-system/references/stat-modifiers.md
+++ b/skills/ability-system/references/stat-modifiers.md
@@ -33,7 +33,7 @@ extends Resource
 enum Operation {
     ADD,       # final += value
     MULTIPLY,  # final *= (1.0 + value)  — e.g. value = 0.2 means +20%
-    OVERRIDE,  # replaces all other results; last applied wins
+    OVERRIDE,  # replaces all other results; highest value wins (last-added wins on ties)
 }
 
 @export var stat_name: String = ""
@@ -55,11 +55,11 @@ public partial class StatModifier : Resource
     {
         Add,       // final += Value
         Multiply,  // final *= (1.0f + Value)  — e.g. Value = 0.2f means +20%
-        Override,  // replaces all other results; last applied wins
+        Override,  // replaces all other results; highest value wins (last-added wins on ties)
     }
 
     [Export] public string StatName  { get; set; } = "";
-    [Export] public Operation Op     { get; set; } = Operation.Add;
+    [Export("operation")] public Operation Op { get; set; } = Operation.Add; // serialized as 'operation' to match the GDScript resource
     [Export] public float Value      { get; set; } = 0.0f;
     [Export] public StringName Source { get; set; } = new StringName("");
 }

--- a/skills/ability-system/references/stat-modifiers.md
+++ b/skills/ability-system/references/stat-modifiers.md
@@ -1,0 +1,416 @@
+# Stat Modifiers and StatSet
+
+Reference for `skills/ability-system/SKILL.md` — the stat-modifier pipeline: `StatModifier` Resource, `StatSet` with computed final values, stacking vs. refresh by source, and the `stat_changed` signal.
+
+> ← Back to [SKILL.md](../SKILL.md)
+
+---
+
+## Overview
+
+A stat-modifier pipeline separates **base stats** (designer-controlled constants) from **runtime modifiers** (applied and removed by abilities, buffs, and equipment). `StatModifier` is a lightweight Resource that describes one change. `StatSet` is a Resource that owns base values and the active modifier list, and computes the final value on demand.
+
+---
+
+## 1. StatModifier Resource
+
+`StatModifier` carries four fields:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `stat_name` | `String` | Identifies the stat to modify (e.g. `"speed"`, `"max_health"`) |
+| `operation` | `Operation` enum | How to combine with existing value: `ADD`, `MULTIPLY`, `OVERRIDE` |
+| `value` | `float` | The operand for the operation |
+| `source` | `StringName` | Opaque key identifying the owner (ability name, buff ID, etc.). Same source = refresh, different sources = stack. |
+
+### GDScript
+
+```gdscript
+# stat_modifier.gd
+class_name StatModifier
+extends Resource
+
+enum Operation {
+    ADD,       # final += value
+    MULTIPLY,  # final *= (1.0 + value)  — e.g. value = 0.2 means +20%
+    OVERRIDE,  # replaces all other results; last applied wins
+}
+
+@export var stat_name: String = ""
+@export var operation: Operation = Operation.ADD
+@export var value: float = 0.0
+@export var source: StringName = &""
+```
+
+### C#
+
+```csharp
+// StatModifier.cs
+using Godot;
+
+[GlobalClass]
+public partial class StatModifier : Resource
+{
+    public enum Operation
+    {
+        Add,       // final += Value
+        Multiply,  // final *= (1.0f + Value)  — e.g. Value = 0.2f means +20%
+        Override,  // replaces all other results; last applied wins
+    }
+
+    [Export] public string StatName  { get; set; } = "";
+    [Export] public Operation Op     { get; set; } = Operation.Add;
+    [Export] public float Value      { get; set; } = 0.0f;
+    [Export] public StringName Source { get; set; } = new StringName("");
+}
+```
+
+---
+
+## 2. StatSet — Base Values, Modifiers, and Computed Final
+
+`StatSet` stores:
+
+- `_base_values`: `Dictionary` mapping `stat_name -> float` — the raw, unmodified numbers.
+- `_modifiers`: `Dictionary` mapping `stat_name -> Dictionary[source, StatModifier]` — one modifier per source per stat (overwriting on re-add enforces refresh semantics).
+
+### Compute order (exact)
+
+Given `base` for a stat and its active modifiers, the final value is computed in three passes:
+
+1. **ADD pass** — sum all `ADD` modifier values and add to base: `running = base + sum(ADD.value)`
+2. **MULTIPLY pass** — for each `MULTIPLY` modifier apply `running *= (1.0 + modifier.value)` in arbitrary order. A `+20%` speed modifier (`value = 0.2`) and a `+10%` modifier (`value = 0.1`) give `running * 1.2 * 1.1 = running * 1.32`. Note: order within the MULTIPLY pass does not matter because multiplication is commutative.
+3. **OVERRIDE pass** — if any `OVERRIDE` modifier exists, its `value` replaces `running` entirely. If multiple OVERRIDEs are present, the one with the highest `value` wins (last-added wins if equal).
+4. **Clamp** — the result is clamped to `[min_value, max_value]` if limits are set for that stat (defaults: `0.0` to `INF`).
+
+> **Why `(1 + value)` for MULTIPLY?** It lets `value = 0.0` be a neutral element (no change), `value = 0.5` mean +50%, and `value = -0.3` mean -30% — intuitive for designers without needing to write `1.3` or `0.7`.
+
+### GDScript
+
+```gdscript
+# stat_set.gd
+class_name StatSet
+extends Resource
+
+signal stat_changed(stat_name: String, new_value: float)
+
+# base_values: { "speed": 300.0, "max_health": 100.0, ... }
+@export var base_values: Dictionary = {}
+
+# Optional per-stat clamp limits. Key = stat_name, value = Vector2(min, max).
+# If a stat has no entry its range is (0.0, INF).
+@export var clamp_limits: Dictionary = {}
+
+# Internal: { stat_name: { source: StatModifier } }
+var _modifiers: Dictionary = {}
+
+
+# Add or refresh a modifier. Calling with the same source replaces the old one.
+func add_modifier(modifier: StatModifier) -> void:
+    var stat := modifier.stat_name
+    if not _modifiers.has(stat):
+        _modifiers[stat] = {}
+    _modifiers[stat][modifier.source] = modifier
+    _emit_if_changed(stat)
+
+
+# Remove the modifier from a given source for a given stat.
+func remove_modifier(stat_name: String, source: StringName) -> void:
+    if _modifiers.has(stat_name):
+        _modifiers[stat_name].erase(source)
+        if _modifiers[stat_name].is_empty():
+            _modifiers.erase(stat_name)
+    _emit_if_changed(stat_name)
+
+
+# Remove all modifiers from a given source across all stats.
+func remove_all_from_source(source: StringName) -> void:
+    var affected: Array[String] = []
+    for stat in _modifiers.keys():
+        if _modifiers[stat].has(source):
+            _modifiers[stat].erase(source)
+            if _modifiers[stat].is_empty():
+                _modifiers.erase(stat)
+            affected.append(stat)
+    for stat in affected:
+        _emit_if_changed(stat)
+
+
+# Return the final computed value for a stat.
+func get_value(stat_name: String) -> float:
+    var base: float = float(base_values.get(stat_name, 0.0))
+    var mods: Dictionary = _modifiers.get(stat_name, {})
+
+    # --- Pass 1: ADD ---
+    var running := base
+    for mod: StatModifier in mods.values():
+        if mod.operation == StatModifier.Operation.ADD:
+            running += mod.value
+
+    # --- Pass 2: MULTIPLY (each modifier scales by its own factor) ---
+    for mod: StatModifier in mods.values():
+        if mod.operation == StatModifier.Operation.MULTIPLY:
+            running *= (1.0 + mod.value)
+
+    # --- Pass 3: OVERRIDE (highest value wins; last-added wins on ties) ---
+    var override_value := -INF
+    var has_override := false
+    for mod: StatModifier in mods.values():
+        if mod.operation == StatModifier.Operation.OVERRIDE:
+            if mod.value >= override_value:
+                override_value = mod.value
+                has_override = true
+    if has_override:
+        running = override_value
+
+    # --- Pass 4: Clamp ---
+    var limits: Vector2 = clamp_limits.get(stat_name, Vector2(0.0, INF))
+    return clamp(running, limits.x, limits.y)
+
+
+# Set a base value and emit if it changed.
+func set_base(stat_name: String, value: float) -> void:
+    base_values[stat_name] = value
+    _emit_if_changed(stat_name)
+
+
+var _last_values: Dictionary = {}
+
+func _emit_if_changed(stat_name: String) -> void:
+    var new_val := get_value(stat_name)
+    if _last_values.get(stat_name, null) != new_val:
+        _last_values[stat_name] = new_val
+        stat_changed.emit(stat_name, new_val)
+```
+
+### C#
+
+```csharp
+// StatSet.cs
+using Godot;
+using System.Collections.Generic;
+
+[GlobalClass]
+public partial class StatSet : Resource
+{
+    [Signal] public delegate void StatChangedEventHandler(string statName, float newValue);
+
+    // base_values: exported so designers can fill them in the Inspector.
+    [Export] public Godot.Collections.Dictionary BaseValues { get; set; } = new();
+
+    // Per-stat clamp limits as Vector2(min, max). If absent: (0, float.PositiveInfinity).
+    [Export] public Godot.Collections.Dictionary ClampLimits { get; set; } = new();
+
+    // stat_name -> (source -> StatModifier)
+    private readonly Dictionary<string, Dictionary<StringName, StatModifier>> _modifiers = new();
+    private readonly Dictionary<string, float> _lastValues = new();
+
+    /// <summary>Add or refresh a modifier. Same source on the same stat replaces the old entry.</summary>
+    public void AddModifier(StatModifier modifier)
+    {
+        if (!_modifiers.TryGetValue(modifier.StatName, out var bySource))
+        {
+            bySource = new Dictionary<StringName, StatModifier>();
+            _modifiers[modifier.StatName] = bySource;
+        }
+        bySource[modifier.Source] = modifier;
+        EmitIfChanged(modifier.StatName);
+    }
+
+    /// <summary>Remove the modifier from a specific source for a specific stat.</summary>
+    public void RemoveModifier(string statName, StringName source)
+    {
+        if (_modifiers.TryGetValue(statName, out var bySource))
+        {
+            bySource.Remove(source);
+            if (bySource.Count == 0)
+                _modifiers.Remove(statName);
+        }
+        EmitIfChanged(statName);
+    }
+
+    /// <summary>Remove all modifiers applied by a given source across all stats.</summary>
+    public void RemoveAllFromSource(StringName source)
+    {
+        var affected = new List<string>();
+        foreach (var (statName, bySource) in _modifiers)
+        {
+            if (bySource.Remove(source))
+                affected.Add(statName);
+        }
+        // Clean up empty inner dicts.
+        foreach (var statName in affected)
+            if (_modifiers.TryGetValue(statName, out var bs) && bs.Count == 0)
+                _modifiers.Remove(statName);
+        foreach (var statName in affected)
+            EmitIfChanged(statName);
+    }
+
+    /// <summary>Compute and return the final value for a stat.</summary>
+    public float GetValue(string statName)
+    {
+        float baseVal = BaseValues.ContainsKey(statName)
+            ? BaseValues[statName].As<float>()
+            : 0f;
+
+        _modifiers.TryGetValue(statName, out var bySource);
+
+        // --- Pass 1: ADD ---
+        float running = baseVal;
+        if (bySource != null)
+            foreach (var mod in bySource.Values)
+                if (mod.Op == StatModifier.Operation.Add)
+                    running += mod.Value;
+
+        // --- Pass 2: MULTIPLY ---
+        if (bySource != null)
+            foreach (var mod in bySource.Values)
+                if (mod.Op == StatModifier.Operation.Multiply)
+                    running *= (1.0f + mod.Value);
+
+        // --- Pass 3: OVERRIDE (highest value wins) ---
+        if (bySource != null)
+        {
+            float overrideVal  = float.NegativeInfinity;
+            bool  hasOverride  = false;
+            foreach (var mod in bySource.Values)
+                if (mod.Op == StatModifier.Operation.Override && mod.Value >= overrideVal)
+                {
+                    overrideVal = mod.Value;
+                    hasOverride = true;
+                }
+            if (hasOverride) running = overrideVal;
+        }
+
+        // --- Pass 4: Clamp ---
+        float min = 0f, max = float.PositiveInfinity;
+        if (ClampLimits.ContainsKey(statName))
+        {
+            var limits = ClampLimits[statName].As<Vector2>();
+            min = limits.X; max = limits.Y;
+        }
+        return Mathf.Clamp(running, min, max);
+    }
+
+    /// <summary>Change a base value and emit if the computed final changes.</summary>
+    public void SetBase(string statName, float value)
+    {
+        BaseValues[statName] = Variant.From(value);
+        EmitIfChanged(statName);
+    }
+
+    private void EmitIfChanged(string statName)
+    {
+        float newVal = GetValue(statName);
+        if (!_lastValues.TryGetValue(statName, out var prev) || prev != newVal)
+        {
+            _lastValues[statName] = newVal;
+            EmitSignal(SignalName.StatChanged, statName, newVal);
+        }
+    }
+}
+```
+
+---
+
+## 3. Stacking vs. Refresh
+
+The inner `Dictionary` keyed by `source` enforces the rule automatically:
+
+- **Same source, re-apply** — `add_modifier` overwrites the existing entry; the old modifier is gone. Use this for abilities that refresh their own buff (e.g. re-casting "Sprint" resets the speed bonus rather than stacking two separate bonuses).
+- **Different sources** — each source occupies its own slot; all of them participate in the compute. Use this for abilities and equipment that legitimately combine (e.g. "Sprint" ability + "Boots of Speed" equipment each contribute their own `ADD` modifier and both take effect).
+
+```gdscript
+# Refresh: re-applying "sprint" removes the previous sprint modifier.
+var sprint_mod := StatModifier.new()
+sprint_mod.stat_name = "speed"
+sprint_mod.operation = StatModifier.Operation.ADD
+sprint_mod.value = 100.0
+sprint_mod.source = &"ability:sprint"
+stat_set.add_modifier(sprint_mod)        # first application
+stat_set.add_modifier(sprint_mod)        # refreshes — still only one modifier, not two
+
+# Stack: boots and sprint are different sources, both active simultaneously.
+var boots_mod := StatModifier.new()
+boots_mod.stat_name = "speed"
+boots_mod.operation = StatModifier.Operation.ADD
+boots_mod.value = 50.0
+boots_mod.source = &"item:boots_of_speed"
+stat_set.add_modifier(boots_mod)
+# speed = base(300) + sprint(100) + boots(50) = 450
+```
+
+```csharp
+// Refresh: re-applying "sprint" replaces the old entry.
+var sprintMod = new StatModifier {
+    StatName  = "speed",
+    Op        = StatModifier.Operation.Add,
+    Value     = 100f,
+    Source    = new StringName("ability:sprint"),
+};
+statSet.AddModifier(sprintMod);  // first application
+statSet.AddModifier(sprintMod);  // refresh — one modifier, not two
+
+// Stack: boots and sprint are separate sources.
+var bootsMod = new StatModifier {
+    StatName  = "speed",
+    Op        = StatModifier.Operation.Add,
+    Value     = 50f,
+    Source    = new StringName("item:boots_of_speed"),
+};
+statSet.AddModifier(bootsMod);
+// speed = base(300) + sprint(100) + boots(50) = 450
+```
+
+---
+
+## 4. Connecting stat_changed to the HUD
+
+`stat_changed(stat_name, new_value)` fires only when the computed final value actually changes. Connect it once in `_ready` and update any UI that reflects the stat:
+
+```gdscript
+# In the entity's root node or a dedicated stats component.
+func _ready() -> void:
+    stat_set.stat_changed.connect(_on_stat_changed)
+
+func _on_stat_changed(stat_name: String, new_value: float) -> void:
+    if stat_name == "max_health":
+        health_bar.max_value = new_value
+    elif stat_name == "speed":
+        # Propagate to CharacterBody2D / CharacterBody3D movement code.
+        movement_component.speed = new_value
+```
+
+```csharp
+public override void _Ready()
+{
+    _statSet.StatChanged += OnStatChanged;
+}
+
+private void OnStatChanged(string statName, float newValue)
+{
+    switch (statName)
+    {
+        case "max_health":
+            _healthBar.MaxValue = newValue;
+            break;
+        case "speed":
+            _movementComponent.Speed = newValue;
+            break;
+    }
+}
+```
+
+> **Tip:** To remove a buff when an ability expires, call `stat_set.remove_modifier(stat_name, source)` from the `Effect.on_expire()` override (see `EffectHolder` in the parent skill). Calling `remove_all_from_source(source)` at expiry is safer when an ability touches multiple stats at once.
+
+---
+
+## Implementation Checklist
+
+- [ ] `StatModifier` Resource created with `stat_name`, `operation`, `value`, `source`
+- [ ] `StatSet` Resource added to caster entity; base values exported and set in the Inspector
+- [ ] `add_modifier` called on ability `activate()`; `remove_modifier` or `remove_all_from_source` called on effect expiry
+- [ ] Compute order confirmed: ADD → MULTIPLY → OVERRIDE → clamp
+- [ ] `clamp_limits` configured for stats with hard caps (e.g. health 0–max, speed 0–1000)
+- [ ] `stat_changed` signal connected to relevant HUD nodes and movement components
+- [ ] Re-applying from the same source refreshes, not stacks (verified by checking modifier count stays at 1)

--- a/skills/ability-system/references/stat-modifiers.md
+++ b/skills/ability-system/references/stat-modifiers.md
@@ -59,9 +59,9 @@ public partial class StatModifier : Resource
     }
 
     [Export] public string StatName  { get; set; } = "";
-    [Export] public ModOp Operation  { get; set; } = ModOp.Add; // property name 'Operation' serializes as 'operation', matching the GDScript field
+    [Export] public ModOp Operation  { get; set; } = ModOp.Add; // serializes as "operation" (snake_case of the property name) — matches the GDScript field
     [Export] public float Value      { get; set; } = 0.0f;
-    [Export] public StringName Source { get; set; } = new StringName("");
+    [Export] public StringName Source { get; set; } = StringName.Empty;
 }
 ```
 

--- a/skills/ability-system/references/tags-and-conditions.md
+++ b/skills/ability-system/references/tags-and-conditions.md
@@ -1,0 +1,562 @@
+# Gameplay Tags and Conditions
+
+Reference for `skills/ability-system/SKILL.md` — the tag system: `GameplayTagContainer` storing `StringName` tags, gating ability activation with required/blocked tags, effect immunities, and a worked "stun blocks casting" example.
+
+> ← Back to [SKILL.md](../SKILL.md)
+
+---
+
+## Overview
+
+A gameplay tag system attaches semantic labels (`StringName`s like `&"status.stunned"` or `&"immune.fire"`) to entities at runtime. Two rules govern the system:
+
+1. **Ability gating** — an `Ability` declares which tags the caster *must* have (`required_tags`) and which tags *prevent* activation (`blocked_tags`). The `can_activate(caster)` virtual checks the caster's `GameplayTagContainer` before firing.
+2. **Effect immunity** — an `Effect` declares what immunity tag blocks it from being applied. The `EffectHolder.apply_effect()` call checks the target's container and silently skips immune targets.
+
+Tags are `StringName`s so comparisons are O(1) hash lookups. Store them in a `Dictionary` (key = tag, value = `true`) for O(1) membership; use an `Array[StringName]` only when order matters (rare).
+
+---
+
+## 1. GameplayTagContainer
+
+`GameplayTagContainer` is a `Resource` so it can be exported on any node and filled in the Godot Inspector.
+
+### GDScript
+
+```gdscript
+# gameplay_tag_container.gd
+class_name GameplayTagContainer
+extends Resource
+
+signal tag_added(tag: StringName)
+signal tag_removed(tag: StringName)
+
+# Internal store: tag -> true. Dictionary gives O(1) has/add/remove.
+var _tags: Dictionary = {}
+
+
+func add_tag(tag: StringName) -> void:
+    if not _tags.has(tag):
+        _tags[tag] = true
+        tag_added.emit(tag)
+
+
+func remove_tag(tag: StringName) -> void:
+    if _tags.erase(tag):
+        tag_removed.emit(tag)
+
+
+func has_tag(tag: StringName) -> bool:
+    return _tags.has(tag)
+
+
+# Returns true if at least one tag in `tags` is present.
+func has_any(tags: Array[StringName]) -> bool:
+    for tag in tags:
+        if _tags.has(tag):
+            return true
+    return false
+
+
+# Returns true only if every tag in `tags` is present.
+func has_all(tags: Array[StringName]) -> bool:
+    for tag in tags:
+        if not _tags.has(tag):
+            return false
+    return true
+
+
+func get_all() -> Array[StringName]:
+    var result: Array[StringName] = []
+    result.assign(_tags.keys())
+    return result
+
+
+func clear() -> void:
+    var removed := get_all()
+    _tags.clear()
+    for tag in removed:
+        tag_removed.emit(tag)
+```
+
+### C#
+
+```csharp
+// GameplayTagContainer.cs
+using Godot;
+using System.Collections.Generic;
+
+[GlobalClass]
+public partial class GameplayTagContainer : Resource
+{
+    [Signal] public delegate void TagAddedEventHandler(StringName tag);
+    [Signal] public delegate void TagRemovedEventHandler(StringName tag);
+
+    private readonly HashSet<StringName> _tags = new();
+
+    public void AddTag(StringName tag)
+    {
+        if (_tags.Add(tag))
+            EmitSignal(SignalName.TagAdded, tag);
+    }
+
+    public void RemoveTag(StringName tag)
+    {
+        if (_tags.Remove(tag))
+            EmitSignal(SignalName.TagRemoved, tag);
+    }
+
+    public bool HasTag(StringName tag) => _tags.Contains(tag);
+
+    /// <summary>Returns true if at least one tag in <paramref name="tags"/> is present.</summary>
+    public bool HasAny(IEnumerable<StringName> tags)
+    {
+        foreach (var tag in tags)
+            if (_tags.Contains(tag)) return true;
+        return false;
+    }
+
+    /// <summary>Returns true only if every tag in <paramref name="tags"/> is present.</summary>
+    public bool HasAll(IEnumerable<StringName> tags)
+    {
+        foreach (var tag in tags)
+            if (!_tags.Contains(tag)) return false;
+        return true;
+    }
+
+    public IReadOnlyCollection<StringName> GetAll() => _tags;
+
+    public void Clear()
+    {
+        var removed = new List<StringName>(_tags);
+        _tags.Clear();
+        foreach (var tag in removed)
+            EmitSignal(SignalName.TagRemoved, tag);
+    }
+}
+```
+
+> **Why `HashSet` in C# but `Dictionary` in GDScript?** GDScript has no built-in `HashSet`, so a `Dictionary` with dummy `true` values gives the same O(1) membership semantics. C# `HashSet<StringName>` is the idiomatic choice there.
+
+---
+
+## 2. Gating Abilities with Required and Blocked Tags
+
+Add two exported arrays to `Ability` and override `can_activate` to query the caster's `GameplayTagContainer`. The container is expected to live as a direct child node *or* be exported on the caster — a helper `_get_tags(caster)` handles both patterns.
+
+### GDScript
+
+```gdscript
+# ability.gd  (extends the base class from SKILL.md Section 2)
+class_name Ability
+extends Resource
+
+@export var ability_name: String
+@export var cost: float = 0.0
+@export var cooldown: float = 1.0
+@export var cast_time: float = 0.0
+
+# Tags the caster must have for this ability to activate.
+@export var required_tags: Array[StringName] = []
+
+# Tags that prevent activation when present on the caster.
+@export var blocked_tags: Array[StringName] = []
+
+
+func can_activate(caster: Node) -> bool:
+    var tags := _get_tags(caster)
+    if tags == null:
+        return true  # no container means no tag constraints
+    if not required_tags.is_empty() and not tags.has_all(required_tags):
+        return false
+    if not blocked_tags.is_empty() and tags.has_any(blocked_tags):
+        return false
+    return true
+
+
+func activate(caster: Node) -> void:
+    pass
+
+
+# Retrieve the GameplayTagContainer from the caster.
+# Checks for a direct-child node first, then an exported property named "tags".
+static func _get_tags(caster: Node) -> GameplayTagContainer:
+    var child := caster.get_node_or_null("GameplayTagContainer")
+    if child is GameplayTagContainer:
+        return child
+    if caster.get("tags") is GameplayTagContainer:
+        return caster.get("tags")
+    return null
+```
+
+### C#
+
+```csharp
+// Ability.cs  (extends the base class from SKILL.md Section 2)
+using Godot;
+using Godot.Collections;
+
+[GlobalClass]
+public partial class Ability : Resource
+{
+    [Export] public string AbilityName { get; set; } = "";
+    [Export] public float Cost         { get; set; } = 0.0f;
+    [Export] public float Cooldown     { get; set; } = 1.0f;
+    [Export] public float CastTime     { get; set; } = 0.0f;
+
+    /// <summary>Tags the caster must have for this ability to activate.</summary>
+    [Export] public Array<StringName> RequiredTags { get; set; } = new();
+
+    /// <summary>Tags that prevent activation when present on the caster.</summary>
+    [Export] public Array<StringName> BlockedTags  { get; set; } = new();
+
+    public virtual bool CanActivate(Node caster)
+    {
+        var tags = GetTags(caster);
+        if (tags == null) return true;
+        if (RequiredTags.Count > 0 && !tags.HasAll(RequiredTags)) return false;
+        if (BlockedTags.Count  > 0 && tags.HasAny(BlockedTags))   return false;
+        return true;
+    }
+
+    public virtual void Activate(Node caster) { }
+
+    /// <summary>
+    /// Locate the <see cref="GameplayTagContainer"/> on the caster.
+    /// Checks for a child node named "GameplayTagContainer" first, then
+    /// falls back to a property named "Tags" on the caster itself.
+    /// </summary>
+    protected static GameplayTagContainer? GetTags(Node caster)
+    {
+        if (caster.GetNodeOrNull("GameplayTagContainer") is GameplayTagContainer child)
+            return child;
+        var prop = caster.Get("tags");
+        return prop.As<GameplayTagContainer>();
+    }
+}
+```
+
+> **Design note:** `_get_tags` / `GetTags` is a static helper so subclasses can call it without boilerplate. If all casters in your project use the same convention (e.g. always a child node), inline it directly and delete the fallback branch.
+
+---
+
+## 3. Effect Immunities
+
+An `Effect` declares one optional immunity tag. Before `EffectHolder.apply_effect()` calls `on_apply`, it checks whether the target owns the immunity tag and skips application entirely if so.
+
+### GDScript
+
+```gdscript
+# effect.gd  (extends the base class from SKILL.md Section 3)
+class_name Effect
+extends Resource
+
+@export var effect_name: String
+@export var duration: float = 5.0
+@export var tick_interval: float = 0.0
+
+# If the target has this tag, the effect is blocked entirely.
+# Leave empty (&"") to make the effect never immune.
+@export var immunity_tag: StringName = &""
+
+func on_apply(target: Node) -> void: pass
+func on_tick(target: Node) -> void: pass
+func on_expire(target: Node) -> void: pass
+```
+
+```gdscript
+# effect_holder.gd  (extends the base class from SKILL.md Section 3)
+class_name EffectHolder
+extends Node
+
+signal effect_applied(effect: Effect)
+signal effect_expired(effect: Effect)
+signal effect_blocked(effect: Effect, reason: String)
+
+var _active: Dictionary = {}
+
+func apply_effect(effect: Effect) -> void:
+    # --- Immunity check ---
+    if effect.immunity_tag != &"":
+        var tags := _get_tags()
+        if tags != null and tags.has_tag(effect.immunity_tag):
+            effect_blocked.emit(effect, "immune")
+            return
+
+    effect.on_apply(get_parent())
+    effect_applied.emit(effect)
+    if effect.duration <= 0.0:
+        effect.on_expire(get_parent())
+        effect_expired.emit(effect)
+        return
+    _active[effect] = [0.0, 0.0]
+
+func _process(delta: float) -> void:
+    var to_remove: Array = []
+    for effect in _active:
+        _active[effect][0] += delta
+        if effect.tick_interval > 0.0:
+            _active[effect][1] += delta
+            if _active[effect][1] >= effect.tick_interval:
+                _active[effect][1] -= effect.tick_interval
+                effect.on_tick(get_parent())
+        if effect.duration > 0.0 and _active[effect][0] >= effect.duration:
+            to_remove.append(effect)
+    for effect in to_remove:
+        _active.erase(effect)
+        effect.on_expire(get_parent())
+        effect_expired.emit(effect)
+
+func _get_tags() -> GameplayTagContainer:
+    var child := get_parent().get_node_or_null("GameplayTagContainer")
+    if child is GameplayTagContainer:
+        return child
+    return null
+```
+
+### C#
+
+```csharp
+// Effect.cs  (extends the base class from SKILL.md Section 3)
+using Godot;
+
+[GlobalClass]
+public partial class Effect : Resource
+{
+    [Export] public string EffectName    { get; set; } = "";
+    [Export] public float  Duration      { get; set; } = 5.0f;
+    [Export] public float  TickInterval  { get; set; } = 0.0f;
+
+    /// <summary>If the target has this tag, the effect is blocked. Empty means never immune.</summary>
+    [Export] public StringName ImmunityTag { get; set; } = new StringName("");
+
+    public virtual void OnApply(Node target)  { }
+    public virtual void OnTick(Node target)   { }
+    public virtual void OnExpire(Node target) { }
+}
+```
+
+```csharp
+// EffectHolder.cs  (extends the base class from SKILL.md Section 3)
+using Godot;
+using System.Collections.Generic;
+
+public partial class EffectHolder : Node
+{
+    [Signal] public delegate void EffectAppliedEventHandler(Effect effect);
+    [Signal] public delegate void EffectExpiredEventHandler(Effect effect);
+    [Signal] public delegate void EffectBlockedEventHandler(Effect effect, string reason);
+
+    private readonly Dictionary<Effect, (float Elapsed, float TickAccum)> _active = new();
+
+    public void ApplyEffect(Effect effect)
+    {
+        // --- Immunity check ---
+        if (effect.ImmunityTag != new StringName(""))
+        {
+            var tags = GetTags();
+            if (tags != null && tags.HasTag(effect.ImmunityTag))
+            {
+                EmitSignal(SignalName.EffectBlocked, effect, "immune");
+                return;
+            }
+        }
+
+        effect.OnApply(GetParent());
+        EmitSignal(SignalName.EffectApplied, effect);
+        if (effect.Duration <= 0f)
+        {
+            effect.OnExpire(GetParent());
+            EmitSignal(SignalName.EffectExpired, effect);
+            return;
+        }
+        _active[effect] = (0f, 0f);
+    }
+
+    public override void _Process(double delta)
+    {
+        var toRemove = new List<Effect>();
+        foreach (var effect in new List<Effect>(_active.Keys))
+        {
+            var (elapsed, tickAccum) = _active[effect];
+            elapsed += (float)delta;
+            if (effect.TickInterval > 0f)
+            {
+                tickAccum += (float)delta;
+                if (tickAccum >= effect.TickInterval)
+                {
+                    tickAccum -= effect.TickInterval;
+                    effect.OnTick(GetParent());
+                }
+            }
+            if (effect.Duration > 0f && elapsed >= effect.Duration)
+                toRemove.Add(effect);
+            else
+                _active[effect] = (elapsed, tickAccum);
+        }
+        foreach (var effect in toRemove)
+        {
+            _active.Remove(effect);
+            effect.OnExpire(GetParent());
+            EmitSignal(SignalName.EffectExpired, effect);
+        }
+    }
+
+    private GameplayTagContainer? GetTags()
+        => GetParent().GetNodeOrNull("GameplayTagContainer") as GameplayTagContainer;
+}
+```
+
+---
+
+## 4. Worked Example — "Stun Blocks Casting"
+
+This example wires together all three pieces: a `StunEffect` that adds the `&"status.stunned"` tag on apply and removes it on expiry, and a `FireballAbility` (or any ability) whose `blocked_tags` includes `&"status.stunned"`.
+
+### Scene tree
+
+```
+Player (CharacterBody2D)
+├── AbilityComponent        ← drives ability activation
+├── EffectHolder            ← manages active effects
+└── GameplayTagContainer    ← owned by the player node
+```
+
+### GDScript
+
+```gdscript
+# stun_effect.gd
+class_name StunEffect
+extends Effect
+
+func _init() -> void:
+    effect_name = "stun"
+    duration = 2.0          # stun lasts 2 seconds
+    tick_interval = 0.0
+    immunity_tag = &"immune.stun"   # entities with this tag resist the stun
+
+func on_apply(target: Node) -> void:
+    var tags := target.get_node_or_null("GameplayTagContainer") as GameplayTagContainer
+    if tags:
+        tags.add_tag(&"status.stunned")
+
+func on_expire(target: Node) -> void:
+    var tags := target.get_node_or_null("GameplayTagContainer") as GameplayTagContainer
+    if tags:
+        tags.remove_tag(&"status.stunned")
+```
+
+```gdscript
+# fireball_ability.gd
+class_name FireballAbility
+extends Ability
+
+func _init() -> void:
+    ability_name = "fireball"
+    cost = 30.0
+    cooldown = 3.0
+    # Stunned casters cannot cast — add the tag to blocked_tags.
+    blocked_tags = [&"status.stunned"]
+
+func activate(caster: Node) -> void:
+    # Spawn fireball projectile here.
+    pass
+```
+
+```gdscript
+# Usage — apply a stun to the player, then watch fireball fail.
+func _on_player_hit_by_stun() -> void:
+    var stun := StunEffect.new()
+    player.get_node("EffectHolder").apply_effect(stun)
+    # 'status.stunned' is now on player's GameplayTagContainer.
+
+    var result := player.get_node("AbilityComponent").try_activate("fireball")
+    # result == false; ability_failed emitted with reason "conditions_unmet".
+    # After 2 s, StunEffect.on_expire removes 'status.stunned';
+    # fireball activates normally again.
+```
+
+### C#
+
+```csharp
+// StunEffect.cs
+using Godot;
+
+[GlobalClass]
+public partial class StunEffect : Effect
+{
+    public StunEffect()
+    {
+        EffectName   = "stun";
+        Duration     = 2.0f;          // stun lasts 2 seconds
+        TickInterval = 0.0f;
+        ImmunityTag  = new StringName("immune.stun");
+    }
+
+    public override void OnApply(Node target)
+    {
+        if (target.GetNodeOrNull("GameplayTagContainer") is GameplayTagContainer tags)
+            tags.AddTag(new StringName("status.stunned"));
+    }
+
+    public override void OnExpire(Node target)
+    {
+        if (target.GetNodeOrNull("GameplayTagContainer") is GameplayTagContainer tags)
+            tags.RemoveTag(new StringName("status.stunned"));
+    }
+}
+```
+
+```csharp
+// FireballAbility.cs
+using Godot;
+using Godot.Collections;
+
+[GlobalClass]
+public partial class FireballAbility : Ability
+{
+    public FireballAbility()
+    {
+        AbilityName  = "fireball";
+        Cost         = 30.0f;
+        Cooldown     = 3.0f;
+        // Stunned casters cannot cast.
+        BlockedTags  = new Array<StringName> { new StringName("status.stunned") };
+    }
+
+    public override void Activate(Node caster)
+    {
+        // Spawn fireball projectile here.
+    }
+}
+```
+
+```csharp
+// Usage — apply a stun to the player, then watch fireball fail.
+private void OnPlayerHitByStun()
+{
+    var stun = new StunEffect();
+    _player.GetNode<EffectHolder>("EffectHolder").ApplyEffect(stun);
+    // "status.stunned" is now in the player's GameplayTagContainer.
+
+    bool result = _player.GetNode<AbilityComponent>("AbilityComponent").TryActivate("fireball");
+    // result == false; AbilityFailed emitted with reason "conditions_unmet".
+    // After 2 s, StunEffect.OnExpire removes "status.stunned";
+    // fireball activates normally again.
+}
+```
+
+> **Flow summary:** `EffectHolder.apply_effect(stun)` → `StunEffect.on_apply` → `tags.add_tag(&"status.stunned")`. Later, `AbilityComponent.try_activate("fireball")` → `ability.can_activate(caster)` → `tags.has_any([&"status.stunned"])` returns `true` → `can_activate` returns `false` → `ability_failed` emitted.
+
+---
+
+## Implementation Checklist
+
+- [ ] `GameplayTagContainer` Resource added as a child node (name `"GameplayTagContainer"`) or exported property `tags` on the entity
+- [ ] `Ability.required_tags` and `Ability.blocked_tags` exported and set in the Inspector
+- [ ] `Ability.can_activate` calls `_get_tags(caster)` / `GetTags(caster)` and checks both arrays
+- [ ] `Effect.immunity_tag` set for effects that should be resistible; leave empty for always-applicable effects
+- [ ] `EffectHolder.apply_effect` checks the immunity tag before calling `on_apply`
+- [ ] `StunEffect` (or equivalent) adds the status tag in `on_apply` and removes it in `on_expire`
+- [ ] `ability_failed` signal connected to HUD or log to surface "conditions_unmet" failures
+- [ ] Tag strings use `StringName` literals (`&"status.stunned"` in GDScript; `new StringName("status.stunned")` in C#) to avoid per-frame allocations

--- a/skills/ability-system/references/tags-and-conditions.md
+++ b/skills/ability-system/references/tags-and-conditions.md
@@ -230,6 +230,7 @@ public partial class Ability : Resource
     {
         if (caster.GetNodeOrNull("GameplayTagContainer") is GameplayTagContainer child)
             return child;
+        // Fallback assumes a GDScript-style "tags" property; a C# caster should expose the container as a named child node.
         var prop = caster.Get("tags");
         return prop.As<GameplayTagContainer>();
     }
@@ -328,7 +329,7 @@ public partial class Effect : Resource
     [Export] public float  TickInterval  { get; set; } = 0.0f;
 
     /// <summary>If the target has this tag, the effect is blocked. Empty means never immune.</summary>
-    [Export] public StringName ImmunityTag { get; set; } = new StringName("");
+    [Export] public StringName ImmunityTag { get; set; } = StringName.Empty;
 
     public virtual void OnApply(Node target)  { }
     public virtual void OnTick(Node target)   { }
@@ -352,7 +353,7 @@ public partial class EffectHolder : Node
     public void ApplyEffect(Effect effect)
     {
         // --- Immunity check ---
-        if (effect.ImmunityTag != new StringName(""))
+        if (effect.ImmunityTag != StringName.Empty)
         {
             var tags = GetTags();
             if (tags != null && tags.HasTag(effect.ImmunityTag))
@@ -471,6 +472,7 @@ func _on_player_hit_by_stun() -> void:
     # 'status.stunned' is now on player's GameplayTagContainer.
 
     var result := player.get_node("AbilityComponent").try_activate("fireball")
+    # `AbilityComponent` (with `try_activate` and the `ability_failed` "conditions_unmet" reason) is defined in the main skill — see Section 2 of SKILL.md.
     # result == false; ability_failed emitted with reason "conditions_unmet".
     # After 2 s, StunEffect.on_expire removes 'status.stunned';
     # fireball activates normally again.
@@ -540,6 +542,7 @@ private void OnPlayerHitByStun()
     // "status.stunned" is now in the player's GameplayTagContainer.
 
     bool result = _player.GetNode<AbilityComponent>("AbilityComponent").TryActivate("fireball");
+    // `AbilityComponent` (with `TryActivate` and the `AbilityFailed` "conditions_unmet" reason) is defined in the main skill — see Section 2 of SKILL.md.
     // result == false; AbilityFailed emitted with reason "conditions_unmet".
     // After 2 s, StunEffect.OnExpire removes "status.stunned";
     // fireball activates normally again.

--- a/skills/ability-system/references/tags-and-conditions.md
+++ b/skills/ability-system/references/tags-and-conditions.md
@@ -19,14 +19,14 @@ Tags are `StringName`s so comparisons are O(1) hash lookups. Store them in a `Di
 
 ## 1. GameplayTagContainer
 
-`GameplayTagContainer` is a `Resource` so it can be exported on any node and filled in the Godot Inspector.
+`GameplayTagContainer` is a `Node` added as a direct child of any entity that needs tags. It can be added in the scene tree and named `"GameplayTagContainer"` for consistent lookup.
 
 ### GDScript
 
 ```gdscript
 # gameplay_tag_container.gd
 class_name GameplayTagContainer
-extends Resource
+extends Node
 
 signal tag_added(tag: StringName)
 signal tag_removed(tag: StringName)
@@ -87,7 +87,7 @@ using Godot;
 using System.Collections.Generic;
 
 [GlobalClass]
-public partial class GameplayTagContainer : Resource
+public partial class GameplayTagContainer : Node
 {
     [Signal] public delegate void TagAddedEventHandler(StringName tag);
     [Signal] public delegate void TagRemovedEventHandler(StringName tag);
@@ -142,7 +142,7 @@ public partial class GameplayTagContainer : Resource
 
 ## 2. Gating Abilities with Required and Blocked Tags
 
-Add two exported arrays to `Ability` and override `can_activate` to query the caster's `GameplayTagContainer`. The container is expected to live as a direct child node *or* be exported on the caster — a helper `_get_tags(caster)` handles both patterns.
+Add two exported arrays to `Ability` and override `can_activate` to query the caster's `GameplayTagContainer`. The container is expected to live as a direct child node named `"GameplayTagContainer"` — a helper `_get_tags(caster)` locates it.
 
 ### GDScript
 
@@ -179,13 +179,11 @@ func activate(caster: Node) -> void:
 
 
 # Retrieve the GameplayTagContainer from the caster.
-# Checks for a direct-child node first, then an exported property named "tags".
+# Looks for a direct child node named "GameplayTagContainer"; returns null if not found.
 static func _get_tags(caster: Node) -> GameplayTagContainer:
     var child := caster.get_node_or_null("GameplayTagContainer")
     if child is GameplayTagContainer:
         return child
-    if caster.get("tags") is GameplayTagContainer:
-        return caster.get("tags")
     return null
 ```
 
@@ -223,21 +221,14 @@ public partial class Ability : Resource
 
     /// <summary>
     /// Locate the <see cref="GameplayTagContainer"/> on the caster.
-    /// Checks for a child node named "GameplayTagContainer" first, then
-    /// falls back to a property named "Tags" on the caster itself.
+    /// Looks for a direct child node named "GameplayTagContainer"; returns null if not found.
     /// </summary>
     protected static GameplayTagContainer? GetTags(Node caster)
-    {
-        if (caster.GetNodeOrNull("GameplayTagContainer") is GameplayTagContainer child)
-            return child;
-        // Fallback assumes a GDScript-style "tags" property; a C# caster should expose the container as a named child node.
-        var prop = caster.Get("tags");
-        return prop.As<GameplayTagContainer>();
-    }
+        => caster.GetNodeOrNull("GameplayTagContainer") as GameplayTagContainer;
 }
 ```
 
-> **Design note:** `_get_tags` / `GetTags` is a static helper so subclasses can call it without boilerplate. If all casters in your project use the same convention (e.g. always a child node), inline it directly and delete the fallback branch.
+> **Design note:** `_get_tags` / `GetTags` is a static helper so subclasses can call it without boilerplate. If you always name the container node `"GameplayTagContainer"`, you can also inline the lookup directly in `can_activate` without the helper.
 
 ---
 
@@ -555,7 +546,7 @@ private void OnPlayerHitByStun()
 
 ## Implementation Checklist
 
-- [ ] `GameplayTagContainer` Resource added as a child node (name `"GameplayTagContainer"`) or exported property `tags` on the entity
+- [ ] `GameplayTagContainer` Node added as a direct child node named `"GameplayTagContainer"` on the entity
 - [ ] `Ability.required_tags` and `Ability.blocked_tags` exported and set in the Inspector
 - [ ] `Ability.can_activate` calls `_get_tags(caster)` / `GetTags(caster)` and checks both arrays
 - [ ] `Effect.immunity_tag` set for effects that should be resistible; leave empty for always-applicable effects

--- a/skills/ability-system/references/ui-binding.md
+++ b/skills/ability-system/references/ui-binding.md
@@ -16,7 +16,7 @@ Connect `AbilityComponent` and `EffectHolder` signals to HUD widgets — no per-
 | `effect_applied(effect)` | `EffectHolder` | `Effect` resource |
 | `effect_expired(effect)` | `EffectHolder` | `Effect` resource |
 
-**Rule:** Bind the HUD to these signals in `_ready`. Never read `_cooldowns` or `_active` directly from the HUD.
+**Rule:** Bind the HUD to these signals via a dedicated `init(player)` call (see §5), not directly in `_ready` — the HUD may be instantiated before the player exists (loading screens, scene transitions). Never read `_cooldowns` or `_active` directly from the HUD.
 
 ---
 
@@ -41,6 +41,10 @@ var _cooldown_remaining: float = 0.0
 var _on_cooldown: bool = false
 
 func bind(ability_component: AbilityComponent) -> void:
+    # `value` is driven as a 0..1 fraction, so the bar's range must be 0..1
+    # (TextureProgressBar defaults to 0..100 — otherwise the sweep looks empty).
+    cooldown_sweep.min_value = 0.0
+    cooldown_sweep.max_value = 1.0
     ability_component.cooldown_started.connect(_on_cooldown_started)
     ability_component.cooldown_finished.connect(_on_cooldown_finished)
     ability_component.ability_activated.connect(_on_ability_activated)
@@ -82,6 +86,7 @@ AbilityIcon (TextureRect)
 ```
 
 Configure `TextureProgressBar`:
+- `min_value` = 0, `max_value` = 1 (the code drives `value` as a 0..1 fraction; set in `bind()`/`_Ready()` above so it works regardless of Inspector defaults)
 - `fill_mode` = `FILL_CLOCKWISE` (radial sweep)
 - `nine_patch_stretch` = off
 - modulate alpha ~0.65 for the tint overlay
@@ -107,6 +112,10 @@ public partial class AbilityIcon : TextureRect
     {
         _cooldownSweep = GetNode<TextureProgressBar>("CooldownSweep");
         _chargeCount = GetNode<Label>("ChargeCount");
+        // Value is driven as a 0..1 fraction, so the bar's range must be 0..1
+        // (TextureProgressBar defaults to 0..100 — otherwise the sweep looks empty).
+        _cooldownSweep.MinValue = 0.0;
+        _cooldownSweep.MaxValue = 1.0;
     }
 
     public void Bind(AbilityComponent component)

--- a/skills/ability-system/references/ui-binding.md
+++ b/skills/ability-system/references/ui-binding.md
@@ -1,0 +1,346 @@
+# HUD Binding for Cooldowns, Resource Bars, and Effect Icons
+
+Connect `AbilityComponent` and `EffectHolder` signals to HUD widgets — no per-frame polling.
+
+> **Related skills:** **hud-system** for HUD architecture and resource-bar patterns, **godot-ui** for Control-tree layout and theming.
+
+---
+
+## 1. Signal contract
+
+| Signal | Source | Payload |
+|---|---|---|
+| `ability_activated(ability)` | `AbilityComponent` | `Ability` resource |
+| `cooldown_started(ability, duration)` | `AbilityComponent` | `Ability`, `float` |
+| `cooldown_finished(ability)` | `AbilityComponent` | `Ability` resource |
+| `effect_applied(effect)` | `EffectHolder` | `Effect` resource |
+| `effect_expired(effect)` | `EffectHolder` | `Effect` resource |
+
+**Rule:** Bind the HUD to these signals in `_ready`. Never read `_cooldowns` or `_active` directly from the HUD.
+
+---
+
+## 2. Cooldown sweep with TextureProgressBar
+
+Use a `TextureProgressBar` in radial mode to display remaining cooldown as a sweep overlay. On `cooldown_started` record the total duration and start a per-frame lerp; on `cooldown_finished` snap to zero and hide the overlay.
+
+### GDScript
+
+```gdscript
+# ability_icon.gd — one per ability slot in the HUD
+class_name AbilityIcon
+extends TextureRect
+
+@export var ability_name: String
+
+@onready var cooldown_sweep: TextureProgressBar = $CooldownSweep
+@onready var charge_count: Label = $ChargeCount
+
+var _cooldown_total: float = 0.0
+var _cooldown_remaining: float = 0.0
+var _on_cooldown: bool = false
+
+func bind(ability_component: AbilityComponent) -> void:
+    ability_component.cooldown_started.connect(_on_cooldown_started)
+    ability_component.cooldown_finished.connect(_on_cooldown_finished)
+    ability_component.ability_activated.connect(_on_ability_activated)
+
+func _on_cooldown_started(ability: Ability, duration: float) -> void:
+    if ability.ability_name != ability_name:
+        return
+    _cooldown_total = duration
+    _cooldown_remaining = duration
+    _on_cooldown = true
+    cooldown_sweep.value = 1.0
+    cooldown_sweep.show()
+
+func _on_cooldown_finished(ability: Ability) -> void:
+    if ability.ability_name != ability_name:
+        return
+    _on_cooldown = false
+    cooldown_sweep.value = 0.0
+    cooldown_sweep.hide()
+
+func _on_ability_activated(ability: Ability) -> void:
+    if ability.ability_name != ability_name:
+        return
+    # Flash or animate the icon on activation (optional).
+
+func _process(delta: float) -> void:
+    if not _on_cooldown:
+        return
+    _cooldown_remaining = maxf(0.0, _cooldown_remaining - delta)
+    # value = 1 when on full cooldown, 0 when ready.
+    cooldown_sweep.value = _cooldown_remaining / _cooldown_total
+```
+
+**Scene tree for one ability slot:**
+```
+AbilityIcon (TextureRect)
+├── CooldownSweep (TextureProgressBar)   ← radial mode, fill texture = dark tint
+└── ChargeCount (Label)                  ← hidden unless ability has charges
+```
+
+Configure `TextureProgressBar`:
+- `fill_mode` = `FILL_CLOCKWISE` (radial sweep)
+- `nine_patch_stretch` = off
+- modulate alpha ~0.65 for the tint overlay
+
+### C#
+
+```csharp
+// AbilityIcon.cs
+using Godot;
+
+public partial class AbilityIcon : TextureRect
+{
+    [Export] public string AbilityName { get; set; } = "";
+
+    private TextureProgressBar _cooldownSweep = null!;
+    private Label _chargeCount = null!;
+
+    private float _cooldownTotal;
+    private float _cooldownRemaining;
+    private bool _onCooldown;
+
+    public override void _Ready()
+    {
+        _cooldownSweep = GetNode<TextureProgressBar>("CooldownSweep");
+        _chargeCount = GetNode<Label>("ChargeCount");
+    }
+
+    public void Bind(AbilityComponent component)
+    {
+        component.CooldownStarted += OnCooldownStarted;
+        component.CooldownFinished += OnCooldownFinished;
+        component.AbilityActivated += OnAbilityActivated;
+    }
+
+    private void OnCooldownStarted(Ability ability, float duration)
+    {
+        if (ability.AbilityName != AbilityName) return;
+        _cooldownTotal = duration;
+        _cooldownRemaining = duration;
+        _onCooldown = true;
+        _cooldownSweep.Value = 1.0;
+        _cooldownSweep.Show();
+    }
+
+    private void OnCooldownFinished(Ability ability)
+    {
+        if (ability.AbilityName != AbilityName) return;
+        _onCooldown = false;
+        _cooldownSweep.Value = 0.0;
+        _cooldownSweep.Hide();
+    }
+
+    private void OnAbilityActivated(Ability ability)
+    {
+        if (ability.AbilityName != AbilityName) return;
+        // Optional: flash animation on activation.
+    }
+
+    public override void _Process(double delta)
+    {
+        if (!_onCooldown) return;
+        _cooldownRemaining = Mathf.Max(0f, _cooldownRemaining - (float)delta);
+        _cooldownSweep.Value = _cooldownTotal > 0f
+            ? _cooldownRemaining / _cooldownTotal
+            : 0.0;
+    }
+}
+```
+
+---
+
+## 3. Charge pips
+
+Abilities with a maximum charge count (e.g. up to 3 uses before a longer recharge) can display pips — small icons that fill/empty as charges are spent and recovered.
+
+```gdscript
+# charge_pips.gd
+class_name ChargePips
+extends HBoxContainer
+
+@export var max_charges: int = 3
+@export var filled_color: Color = Color.WHITE
+@export var empty_color: Color = Color(1, 1, 1, 0.3)
+
+var _pips: Array[ColorRect] = []
+var _current_charges: int
+
+func _ready() -> void:
+    _current_charges = max_charges
+    for i in max_charges:
+        var pip := ColorRect.new()
+        pip.custom_minimum_size = Vector2(12, 12)
+        pip.color = filled_color
+        add_child(pip)
+        _pips.append(pip)
+
+func set_charges(count: int) -> void:
+    _current_charges = clampi(count, 0, max_charges)
+    for i in _pips.size():
+        _pips[i].color = filled_color if i < _current_charges else empty_color
+
+# Call set_charges() from AbilityComponent signals or from game logic
+# that tracks how many charges remain.
+```
+
+```csharp
+// ChargePips.cs
+using Godot;
+using System.Collections.Generic;
+
+public partial class ChargePips : HBoxContainer
+{
+    [Export] public int MaxCharges { get; set; } = 3;
+    [Export] public Color FilledColor { get; set; } = Colors.White;
+    [Export] public Color EmptyColor { get; set; } = new Color(1, 1, 1, 0.3f);
+
+    private readonly List<ColorRect> _pips = new();
+
+    public override void _Ready()
+    {
+        for (int i = 0; i < MaxCharges; i++)
+        {
+            var pip = new ColorRect
+            {
+                CustomMinimumSize = new Vector2(12, 12),
+                Color = FilledColor
+            };
+            AddChild(pip);
+            _pips.Add(pip);
+        }
+    }
+
+    public void SetCharges(int count)
+    {
+        int clamped = Mathf.Clamp(count, 0, MaxCharges);
+        for (int i = 0; i < _pips.Count; i++)
+            _pips[i].Color = i < clamped ? FilledColor : EmptyColor;
+    }
+}
+```
+
+---
+
+## 4. Buff/debuff icon row
+
+Listen to `effect_applied` and `effect_expired` from `EffectHolder` to add/remove icons. Each icon can show a countdown label driven from `_process` while the effect is active.
+
+### GDScript
+
+```gdscript
+# effect_icon_row.gd
+class_name EffectIconRow
+extends HBoxContainer
+
+# Preloaded per-effect scene: TextureRect + Label for remaining time.
+@export var effect_icon_scene: PackedScene
+
+var _icon_map: Dictionary = {}  # Effect -> Control node
+
+func bind(effect_holder: EffectHolder) -> void:
+    effect_holder.effect_applied.connect(_on_effect_applied)
+    effect_holder.effect_expired.connect(_on_effect_expired)
+
+func _on_effect_applied(effect: Effect) -> void:
+    if _icon_map.has(effect):
+        return
+    var icon: Control = effect_icon_scene.instantiate()
+    icon.name = effect.effect_name
+    # Set texture from effect data if your Effect Resource carries one.
+    add_child(icon)
+    _icon_map[effect] = icon
+
+func _on_effect_expired(effect: Effect) -> void:
+    if not _icon_map.has(effect):
+        return
+    _icon_map[effect].queue_free()
+    _icon_map.erase(effect)
+```
+
+### C#
+
+```csharp
+// EffectIconRow.cs
+using Godot;
+using System.Collections.Generic;
+
+public partial class EffectIconRow : HBoxContainer
+{
+    [Export] public PackedScene EffectIconScene { get; set; } = null!;
+
+    private readonly Dictionary<Effect, Control> _iconMap = new();
+
+    public void Bind(EffectHolder effectHolder)
+    {
+        effectHolder.EffectApplied += OnEffectApplied;
+        effectHolder.EffectExpired += OnEffectExpired;
+    }
+
+    private void OnEffectApplied(Effect effect)
+    {
+        if (_iconMap.ContainsKey(effect)) return;
+        var icon = EffectIconScene.Instantiate<Control>();
+        icon.Name = effect.EffectName;
+        AddChild(icon);
+        _iconMap[effect] = icon;
+    }
+
+    private void OnEffectExpired(Effect effect)
+    {
+        if (!_iconMap.TryGetValue(effect, out var icon)) return;
+        icon.QueueFree();
+        _iconMap.Remove(effect);
+    }
+}
+```
+
+---
+
+## 5. Wiring it up in the HUD
+
+```gdscript
+# hud.gd
+extends CanvasLayer
+
+@onready var fireball_icon: AbilityIcon = $AbilityBar/FireballIcon
+@onready var effect_row: EffectIconRow = $EffectRow
+
+func init(player: Node) -> void:
+    var ability_comp: AbilityComponent = player.get_node("AbilityComponent")
+    var effect_holder: EffectHolder = player.get_node("EffectHolder")
+
+    fireball_icon.bind(ability_comp)
+    effect_row.bind(effect_holder)
+```
+
+```csharp
+// Hud.cs
+using Godot;
+
+public partial class Hud : CanvasLayer
+{
+    private AbilityIcon _fireballIcon = null!;
+    private EffectIconRow _effectRow = null!;
+
+    public override void _Ready()
+    {
+        _fireballIcon = GetNode<AbilityIcon>("AbilityBar/FireballIcon");
+        _effectRow = GetNode<EffectIconRow>("EffectRow");
+    }
+
+    public void Init(Node player)
+    {
+        var abilityComp = player.GetNode<AbilityComponent>("AbilityComponent");
+        var effectHolder = player.GetNode<EffectHolder>("EffectHolder");
+
+        _fireballIcon.Bind(abilityComp);
+        _effectRow.Bind(effectHolder);
+    }
+}
+```
+
+> **Footgun:** Connect HUD signals in a dedicated `init(player)` call rather than directly in `_ready`, so the HUD can be instantiated before the player node exists (e.g., loading screens, scene transitions).

--- a/skills/ability-system/references/ui-binding.md
+++ b/skills/ability-system/references/ui-binding.md
@@ -71,7 +71,7 @@ func _process(delta: float) -> void:
         return
     _cooldown_remaining = maxf(0.0, _cooldown_remaining - delta)
     # value = 1 when on full cooldown, 0 when ready.
-    cooldown_sweep.value = _cooldown_remaining / _cooldown_total
+    cooldown_sweep.value = _cooldown_remaining / _cooldown_total if _cooldown_total > 0.0 else 0.0
 ```
 
 **Scene tree for one ability slot:**
@@ -199,6 +199,7 @@ public partial class ChargePips : HBoxContainer
     [Export] public Color EmptyColor { get; set; } = new Color(1, 1, 1, 0.3f);
 
     private readonly List<ColorRect> _pips = new();
+    private int _currentCharges;
 
     public override void _Ready()
     {
@@ -216,9 +217,9 @@ public partial class ChargePips : HBoxContainer
 
     public void SetCharges(int count)
     {
-        int clamped = Mathf.Clamp(count, 0, MaxCharges);
+        _currentCharges = Mathf.Clamp(count, 0, MaxCharges);
         for (int i = 0; i < _pips.Count; i++)
-            _pips[i].Color = i < clamped ? FilledColor : EmptyColor;
+            _pips[i].Color = i < _currentCharges ? FilledColor : EmptyColor;
     }
 }
 ```

--- a/skills/ai-navigation/SKILL.md
+++ b/skills/ai-navigation/SKILL.md
@@ -7,7 +7,7 @@ description: Use when implementing AI movement — NavigationAgent2D/3D, steerin
 
 Cover NavigationAgent2D/3D, steering behaviors, behavior trees, and patrol patterns. All examples target Godot 4.3+ with no deprecated APIs.
 
-> **Related skills:** **state-machine** for AI state management, **component-system** for modular AI behaviors, **player-controller** for movement physics patterns, **math-essentials** for pathfinding vectors and steering math.
+> **Related skills:** **state-machine** for AI state management, **component-system** for modular AI behaviors, **player-controller** for movement physics patterns, **math-essentials** for pathfinding vectors and steering math, **limboai** for BT + HSM with a visual editor, **beehave** for lightweight GDScript behavior trees. For a structured behavior tree (rather than steering/navigation), see the comparison tables in **limboai** and **beehave**.
 
 ---
 

--- a/skills/beehave/SKILL.md
+++ b/skills/beehave/SKILL.md
@@ -117,10 +117,12 @@ extends ConditionLeaf
 @export var detection_range: float = 150.0
 
 func tick(actor: Node, blackboard: Blackboard) -> int:
+    # Beehave types `actor` as Node; cast to your concrete type for 2D members.
+    var body := actor as Node2D
     var target: Node2D = blackboard.get_value("target")
-    if not is_instance_valid(target):
+    if body == null or not is_instance_valid(target):
         return FAILURE
-    var in_range := actor.global_position.distance_to(target.global_position) <= detection_range
+    var in_range := body.global_position.distance_to(target.global_position) <= detection_range
     return SUCCESS if in_range else FAILURE
 ```
 
@@ -137,7 +139,9 @@ func tick(actor: Node, blackboard: Blackboard) -> int:
 
     if elapsed >= attack_duration:
         blackboard.erase_value("attack_elapsed")
-        actor.play_attack_animation()
+        # `actor` is typed Node; guard game-specific methods (or cast to your actor type).
+        if actor.has_method("play_attack_animation"):
+            actor.call("play_attack_animation")
         return SUCCESS
 
     blackboard.set_value("attack_elapsed", elapsed)

--- a/skills/beehave/SKILL.md
+++ b/skills/beehave/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: beehave
+description: Use when using the Beehave addon — pure-GDScript behavior trees with composites, decorators, leaves, a blackboard, and a visual runtime debugger
+---
+
+# Beehave
+
+> **Related skills:** **ai-navigation** for the movement leaves drive, **state-machine** for core-engine FSM, **limboai** for a heavier C++ BT+HSM alternative, **godot-brainstorming** for choosing an AI approach.
+
+> **Addon:** Beehave · version `v2.9.2` · Godot 4.1+ · MIT · source: https://github.com/bitbrain/beehave · written in GDScript (no official C# API — this skill is GDScript-only by design).
+
+---
+
+## 1. When to use Beehave
+
+| Approach | Best for |
+|---|---|
+| Core-engine FSM (`state-machine` skill) | Simple agents, < 5 states, no addon |
+| **Beehave** (GDScript addon) | Lightweight BT, GDScript-only projects, fast iteration |
+| **LimboAI** | BT **and** HSM together, visual editor, C++ performance, C# support (module build) |
+
+Choose Beehave when your project is GDScript-only, you want a behavior tree without a custom engine build, and you value a simple node-in-scene-tree authoring workflow. Beehave trees live entirely in the scene tree — every composite, decorator, and leaf is a regular `Node` child. For a heavier C++/C# solution with HSM integration, use the `limboai` skill instead. For plain state machines without a BT, use the built-in `state-machine` skill.
+
+**C# note:** Beehave has no official C# API (zero `.cs` files in `addons/beehave/`). From C# you can call the GDScript API via Godot cross-language interop (`GetNode<Node>(...).Call("tick", actor, blackboard)`), but Beehave provides no typed C# classes.
+
+---
+
+## 2. Install & enable
+
+1. **Godot AssetLib** → search "Beehave" → Download → Reload project.  
+   Or copy the `addons/beehave/` folder from the [GitHub release](https://github.com/bitbrain/beehave/releases) into `res://addons/beehave/`.
+2. Enable the plugin: **Project → Project Settings → Plugins** → tick **Beehave**.  
+   Two autoloads are registered: `BeehaveGlobalMetrics` and `BeehaveGlobalDebugger`.
+3. Optional — copy `script_templates/` from the addon into the project root for leaf scaffolding templates.
+
+---
+
+## 3. Tree composition
+
+A Beehave tree is built from three kinds of nodes, all placed as regular scene-tree children:
+
+| Role | Node | Behavior |
+|---|---|---|
+| **Tree root** | `BeehaveTree` | Ticks the child every frame (or physics/manual); extends `Node` (not `BeehaveNode`) |
+| **Composites** | `SequenceComposite`, `SelectorComposite`, `SimpleParallelComposite`, … | Flow control — AND / OR / parallel logic |
+| **Decorators** | `InverterDecorator`, `CooldownDecorator`, `RepeaterDecorator`, … | Wrap one child to modify its result |
+| **Leaves** | `ActionLeaf`, `ConditionLeaf` subclasses | Your custom game logic |
+
+### Composite quick reference
+
+| Class | Logic |
+|---|---|
+| `SequenceComposite` | AND — all children must succeed; fails on first failure |
+| `SequenceReactiveComposite` | AND — re-evaluates from first child every tick while running |
+| `SelectorComposite` | OR — succeeds on first success; fails if all fail |
+| `SelectorReactiveComposite` | OR — re-evaluates from first child every tick while running |
+| `SimpleParallelComposite` | Runs two children simultaneously; result follows primary (child 0) |
+| `SequenceRandomComposite` | Shuffled AND — executes children in random order |
+| `SelectorRandomComposite` | Shuffled OR — tries children in random order |
+
+### Decorator quick reference
+
+| Class | Effect |
+|---|---|
+| `InverterDecorator` | Flips `SUCCESS` ↔ `FAILURE`; passes `RUNNING` through |
+| `AlwaysSucceedDecorator` | Forces `SUCCESS`; passes `RUNNING` through |
+| `AlwaysFailDecorator` | Forces `FAILURE`; passes `RUNNING` through |
+| `RepeaterDecorator` | Re-runs child until it succeeds `repetitions` times |
+| `LimiterDecorator` | Caps child to `max_count` running ticks, then `FAILURE` |
+| `CooldownDecorator` | Blocks re-execution for `wait_time` seconds after child finishes |
+| `TimeLimiterDecorator` | Gives child `wait_time` seconds; interrupts if still running |
+| `DelayDecorator` | Waits `wait_time` seconds before first executing child |
+| `UntilFailDecorator` | Loops child until it returns `FAILURE`, then returns `SUCCESS` |
+
+### Minimal scene-tree example
+
+```gdscript
+# Scene tree:
+#   Enemy (CharacterBody2D)
+#     BeehaveTree               ← tick_rate = 1, process_thread = PHYSICS
+#       SelectorComposite
+#         SequenceComposite     ← "attack if in range"
+#           IsInRangeCondition
+#           AttackAction
+#         PatrolAction          ← fallback
+
+# BeehaveTree exports:
+# @export var enabled: bool = true
+# @export var tick_rate: int = 1          (1 = every frame; 3 = every 3 frames)
+# @export var process_thread: ProcessThread = PHYSICS
+# @export var blackboard: Blackboard      (auto-created if not set)
+# @export_node_path var actor_node_path   (defaults to parent node)
+
+# Access the tree from code if you need manual control:
+@onready var bt: BeehaveTree = $BeehaveTree
+
+func _ready() -> void:
+    # Reduce tick cost: evaluate AI every 3 physics frames
+    bt.tick_rate = 3
+    # Default process_thread is PHYSICS — switch to IDLE if actor uses _process
+    bt.process_thread = BeehaveTree.ProcessThread.IDLE
+```
+
+> **tick_rate note:** `tick_rate = 1` evaluates every frame; `tick_rate = 3` every 3 frames. Increase for distant/background NPCs to save CPU. Default process thread is `PHYSICS` — if the actor script uses `_process` instead of `_physics_process`, set `process_thread = IDLE` to keep them in sync.
+
+---
+
+## 4. The leaf contract
+
+Leaves hold your game logic. Subclass `ActionLeaf` for multi-tick work or `ConditionLeaf` for single-frame checks, then override `tick(actor, blackboard)`.
+
+```gdscript
+# IsInRangeCondition.gd
+class_name IsInRangeCondition
+extends ConditionLeaf
+
+@export var detection_range: float = 150.0
+
+func tick(actor: Node, blackboard: Blackboard) -> int:
+    var target: Node2D = blackboard.get_value("target")
+    if not is_instance_valid(target):
+        return FAILURE
+    var in_range := actor.global_position.distance_to(target.global_position) <= detection_range
+    return SUCCESS if in_range else FAILURE
+```
+
+```gdscript
+# AttackAction.gd
+class_name AttackAction
+extends ActionLeaf
+
+@export var attack_duration: float = 0.5
+
+func tick(actor: Node, blackboard: Blackboard) -> int:
+    var elapsed: float = blackboard.get_value("attack_elapsed", 0.0)
+    elapsed += get_physics_process_delta_time()
+
+    if elapsed >= attack_duration:
+        blackboard.erase_value("attack_elapsed")
+        actor.play_attack_animation()
+        return SUCCESS
+
+    blackboard.set_value("attack_elapsed", elapsed)
+    return RUNNING
+
+func after_run(actor: Node, blackboard: Blackboard) -> void:
+    # Clean up any per-run state when the tree interrupts this action
+    blackboard.erase_value("attack_elapsed")
+```
+
+**Return codes** (defined on `BeehaveNode`):
+- `SUCCESS` — action complete / condition met.
+- `FAILURE` — action failed / condition not met; parent composite decides what to do next.
+- `RUNNING` — action needs more frames; tree will call `tick()` again next frame (`ActionLeaf` only — `ConditionLeaf` should never return `RUNNING`).
+
+**Optional overrides:**
+- `before_run(actor, blackboard)` — called once before the first tick of a run.
+- `after_run(actor, blackboard)` — called when the child finishes (`SUCCESS`/`FAILURE`) or is interrupted.
+- `interrupt(actor, blackboard)` — called when the tree interrupts a running node.
+
+---
+
+## 5. Blackboard
+
+The `Blackboard` node is a shared key/value store passed to every `tick()` call. `BeehaveTree` auto-creates an internal one if you don't assign an external `Blackboard` node.
+
+```gdscript
+# Share one Blackboard across multiple BeehaveTrees on the same actor.
+# Assign the same exported Blackboard node to each tree in the Inspector.
+
+# Read / write from any leaf's tick():
+func tick(actor: Node, blackboard: Blackboard) -> int:
+    # Write
+    blackboard.set_value("target", actor.get_nearest_enemy())
+
+    # Read with default
+    var speed: float = blackboard.get_value("move_speed", 200.0)
+
+    # Conditional check
+    if blackboard.has_value("stunned"):
+        return FAILURE
+
+    # Erase (sets key to null; has_value returns false after erase)
+    blackboard.erase_value("temp_flag")
+
+    return SUCCESS
+```
+
+> **Named namespaces:** every method accepts an optional `blackboard_name: String` parameter (default `"default"`). Use this to keep separate namespaces on one `Blackboard` node without name collisions (e.g., per-enemy state vs. shared world state).
+
+> **Built-in expression leaves:** `BlackboardSetAction`, `BlackboardEraseAction`, `BlackboardHasCondition`, and `BlackboardCompareCondition` let you manipulate the Blackboard entirely via Inspector exports (no GDScript required). Expressions run via Godot's `Expression.execute([], blackboard)` — so you can call `get_value("key")` directly in the expression string.
+
+---
+
+## 6. Visual debugger
+
+Beehave ships an `EditorDebuggerPlugin` that adds a **🐝 Beehave** tab to the bottom editor panel while your game is running:
+
+1. Run the project from the Godot editor.
+2. Open the **Debugger** panel → click the **🐝 Beehave** tab.
+3. Select a tree from the list to activate live visualization — active nodes are highlighted each tick.
+4. Optional: click the detach button to float the panel, or set **Project Settings → beehave/debugger/start_detached = true** to always start detached.
+
+To track per-tree CPU cost in the **Performance** panel, set `custom_monitor = true` on the `BeehaveTree` node. This registers `beehave [microseconds]/process_time_<actor_name>-<id>` as a Performance monitor.
+
+For a walkthrough of writing custom decorators and conditions, see [references/custom-nodes.md](references/custom-nodes.md).
+
+---
+
+## Implementation checklist
+
+- [ ] `addons/beehave/` copied into project; plugin enabled in **Project Settings → Plugins**
+- [ ] `BeehaveTree` added as a child of the actor; `actor_node_path` set (or left blank to default to parent)
+- [ ] `process_thread` matches actor's loop: `PHYSICS` for `_physics_process`, `IDLE` for `_process`
+- [ ] `tick_rate` tuned — increase for background NPCs (e.g., `3`) to reduce per-frame cost
+- [ ] Every `tick()` override returns `SUCCESS`, `FAILURE`, or `RUNNING` — never `void`/`null`
+- [ ] `ConditionLeaf` subclasses never return `RUNNING`
+- [ ] Per-run state written to the `Blackboard`, not stored on the leaf node itself (leaf nodes are shared)
+- [ ] `after_run` or `interrupt` cleans up any Blackboard keys the action wrote
+- [ ] External `Blackboard` node exported and shared when multiple `BeehaveTree` nodes need the same data
+- [ ] Visual debugger checked at runtime to verify tick flow before shipping AI logic

--- a/skills/beehave/references/custom-nodes.md
+++ b/skills/beehave/references/custom-nodes.md
@@ -50,20 +50,26 @@ extends ActionLeaf
 const ARRIVE_DIST := 8.0
 
 func tick(actor: Node, blackboard: Blackboard) -> int:
+    # Beehave types `actor` as Node; cast to CharacterBody2D for the movement API.
+    var body := actor as CharacterBody2D
+    if body == null:
+        return FAILURE
     var target_pos: Vector2 = blackboard.get_value("target_pos", Vector2.ZERO)
-    if actor.global_position.distance_to(target_pos) <= ARRIVE_DIST:
+    if body.global_position.distance_to(target_pos) <= ARRIVE_DIST:
         _clear(blackboard)
         return SUCCESS
 
-    var dir := actor.global_position.direction_to(target_pos)
-    actor.velocity = dir * blackboard.get_value("move_speed", 150.0)
-    actor.move_and_slide()
+    var dir := body.global_position.direction_to(target_pos)
+    body.velocity = dir * blackboard.get_value("move_speed", 150.0)
+    body.move_and_slide()
     blackboard.set_value("is_moving", true)
     return RUNNING
 
 func interrupt(actor: Node, blackboard: Blackboard) -> void:
     _clear(blackboard)
-    actor.velocity = Vector2.ZERO
+    var body := actor as CharacterBody2D
+    if body != null:
+        body.velocity = Vector2.ZERO
 
 func after_run(actor: Node, blackboard: Blackboard) -> void:
     _clear(blackboard)

--- a/skills/beehave/references/custom-nodes.md
+++ b/skills/beehave/references/custom-nodes.md
@@ -1,0 +1,155 @@
+# Beehave — Custom Nodes & Advanced Patterns
+
+Reference for writing custom decorators and conditions, advanced Blackboard patterns, and runtime manual-tick control. Companion to `skills/beehave/SKILL.md`.
+
+---
+
+## Custom decorator
+
+Subclass `Decorator` and override `tick(actor, blackboard)`. A decorator must have **exactly one** BeehaveNode child. Access it via `get_children()[0]` (or call `_safe_tick` on the child directly as Beehave's internal nodes do).
+
+```gdscript
+# DebugDecorator.gd — prints the child result each tick (useful during development)
+class_name DebugDecorator
+extends Decorator
+
+@export var label: String = "debug"
+
+func tick(actor: Node, blackboard: Blackboard) -> int:
+    var child := get_children()[0] as BeehaveNode
+    var result := child._safe_tick(actor, blackboard)
+    var result_name := ["SUCCESS", "FAILURE", "RUNNING"][result]
+    print("[%s] %s → %s" % [label, child.name, result_name])
+    return result
+```
+
+---
+
+## Custom condition
+
+```gdscript
+# HasAmmoCondition.gd — checks a property on the actor, no Blackboard needed
+class_name HasAmmoCondition
+extends ConditionLeaf
+
+func tick(actor: Node, blackboard: Blackboard) -> int:
+    return SUCCESS if actor.ammo > 0 else FAILURE
+```
+
+---
+
+## Custom action with interrupt cleanup
+
+When a `SequenceReactiveComposite` or `SelectorReactiveComposite` re-evaluates from the first child while an action is RUNNING, it calls `interrupt()` on the running node. Always pair per-run Blackboard writes with cleanup:
+
+```gdscript
+# MoveToTargetAction.gd
+class_name MoveToTargetAction
+extends ActionLeaf
+
+const ARRIVE_DIST := 8.0
+
+func tick(actor: Node, blackboard: Blackboard) -> int:
+    var target_pos: Vector2 = blackboard.get_value("target_pos", Vector2.ZERO)
+    if actor.global_position.distance_to(target_pos) <= ARRIVE_DIST:
+        _clear(blackboard)
+        return SUCCESS
+
+    var dir := actor.global_position.direction_to(target_pos)
+    actor.velocity = dir * blackboard.get_value("move_speed", 150.0)
+    actor.move_and_slide()
+    blackboard.set_value("is_moving", true)
+    return RUNNING
+
+func interrupt(actor: Node, blackboard: Blackboard) -> void:
+    _clear(blackboard)
+    actor.velocity = Vector2.ZERO
+
+func after_run(actor: Node, blackboard: Blackboard) -> void:
+    _clear(blackboard)
+
+func _clear(blackboard: Blackboard) -> void:
+    blackboard.erase_value("is_moving")
+```
+
+---
+
+## Manual tick (MANUAL process thread)
+
+Set `process_thread = MANUAL` to drive the tree yourself — useful for turn-based or time-sliced AI:
+
+```gdscript
+# TurnManager.gd — tick all enemy trees once per turn
+extends Node
+
+@export var enemies: Array[Node] = []
+
+func execute_enemy_turn() -> void:
+    for enemy in enemies:
+        var bt: BeehaveTree = enemy.get_node("BeehaveTree")
+        var result := bt.tick()
+        # result is SUCCESS, FAILURE, or RUNNING (int enum on BeehaveNode)
+        if result == BeehaveNode.RUNNING:
+            # Enemy needs more turns — re-queue for next call
+            pass
+```
+
+`bt.tick()` returns the integer status code. In MANUAL mode `BeehaveTree` never calls `tick()` on its own — it only runs when you call it.
+
+---
+
+## Sharing a Blackboard across multiple trees
+
+One common pattern: give the actor a single `Blackboard` node and export it into several `BeehaveTree` nodes (e.g., movement tree + combat tree). All trees read/write the same key space.
+
+```gdscript
+# In the actor's _ready(), or wire via Inspector exports:
+@onready var shared_bb: Blackboard = $Blackboard
+@onready var combat_tree: BeehaveTree = $CombatTree
+@onready var movement_tree: BeehaveTree = $MovementTree
+
+func _ready() -> void:
+    combat_tree.blackboard = shared_bb
+    movement_tree.blackboard = shared_bb
+```
+
+Use named namespaces to avoid key collisions between subsystems:
+
+```gdscript
+# Combat leaf — writes into "combat" namespace
+blackboard.set_value("target", enemy, "combat")
+
+# Movement leaf — reads from default namespace; isolated from combat keys
+var speed: float = blackboard.get_value("move_speed", 200.0)
+```
+
+---
+
+## Weight-based random composites
+
+`SequenceRandomComposite` and `SelectorRandomComposite` support per-child weights via `RandomizedComposite`. Enable via the Inspector:
+
+1. Select the random composite node.
+2. Set **use_weights = true** in the Inspector.
+3. Per-child `Weights/<child_name>` integer properties (1–100) appear dynamically in the Inspector.
+
+There is no GDScript API to set weights at runtime — weight configuration is inspector-only in v2.9.2.
+
+---
+
+## Known issues (v2.9.2)
+
+- **`RepeaterDecorator.get_class_name()` bug:** The method returns `&"LimiterDecorator"` instead of `&"RepeaterDecorator"` due to a copy-paste error in the source. The actual GDScript `class_name` is `RepeaterDecorator` (autocomplete and `is` checks work correctly); only `get_class_name()` returns the wrong value. Avoid `get_class_name()` for identity checks on this node.
+
+---
+
+## Built-in expression leaves (no GDScript required)
+
+| Node | Purpose |
+|---|---|
+| `BlackboardSetAction` | Sets `key` → `value` (GDScript expressions evaluated against Blackboard) |
+| `BlackboardEraseAction` | Erases a key from the Blackboard |
+| `BlackboardHasCondition` | `SUCCESS` if key exists and is non-null |
+| `BlackboardCompareCondition` | Compares two expressions with `==`, `!=`, `>`, `<`, `>=`, `<=` |
+
+Expressions run via `Expression.execute([], blackboard)` — the Blackboard is the base instance, so you can call `get_value("health")` directly in the expression string.

--- a/skills/component-system/SKILL.md
+++ b/skills/component-system/SKILL.md
@@ -7,7 +7,7 @@ description: Use when building reusable node components — composition patterns
 
 Build behavior through composition. Attach small, focused components to any entity rather than climbing an inheritance chain. All examples target Godot 4.3+ with no deprecated APIs.
 
-> **Related skills:** **scene-organization** for scene tree composition, **event-bus** for decoupled component communication, **resource-pattern** for data-driven component configuration, **physics-system** for Area2D/3D overlap detection and collision shapes.
+> **Related skills:** **scene-organization** for scene tree composition, **event-bus** for decoupled component communication, **resource-pattern** for data-driven component configuration, **physics-system** for Area2D/3D overlap detection and collision shapes, **ability-system** for an AbilityComponent example built on this pattern.
 
 ---
 

--- a/skills/event-bus/SKILL.md
+++ b/skills/event-bus/SKILL.md
@@ -7,7 +7,7 @@ description: Use when implementing decoupled communication between nodes — glo
 
 A global signal hub that lets unrelated nodes communicate without holding references to each other. All examples target Godot 4.3+ with no deprecated APIs.
 
-> **Related skills:** **component-system** for direct signal communication between components, **csharp-signals** for C#-specific signal patterns, **dependency-injection** for alternative decoupling approaches.
+> **Related skills:** **component-system** for direct signal communication between components, **csharp-signals** for C#-specific signal patterns, **dependency-injection** for alternative decoupling approaches, **ability-system** for an EventBus usage example with ability events.
 
 ---
 

--- a/skills/hud-system/SKILL.md
+++ b/skills/hud-system/SKILL.md
@@ -7,7 +7,7 @@ description: Use when building in-game HUDs — health bars, score displays, min
 
 All examples target Godot 4.3+ with no deprecated APIs. GDScript is shown first, then C#.
 
-> **Related skills:** **godot-ui** for Control node layout and themes, **component-system** for HealthComponent integration, **event-bus** for score/notification signals, **inventory-system** for inventory UI patterns, **2d-essentials** for CanvasLayer setup and draw order.
+> **Related skills:** **godot-ui** for Control node layout and themes, **component-system** for HealthComponent integration, **event-bus** for score/notification signals, **inventory-system** for inventory UI patterns, **2d-essentials** for CanvasLayer setup and draw order, **ability-system** for cooldown bar and resource bar binding patterns.
 
 ---
 

--- a/skills/limboai/SKILL.md
+++ b/skills/limboai/SKILL.md
@@ -44,6 +44,7 @@ linux.debug.x86_64     = "res://addons/limboai/bin/liblimboai.linux.editor.x86_6
 linux.release.x86_64   = "res://addons/limboai/bin/liblimboai.linux.template_release.x86_64.so"
 macos.debug            = "res://addons/limboai/bin/liblimboai.macos.editor.framework"
 macos.release          = "res://addons/limboai/bin/liblimboai.macos.template_release.framework"
+# ... (additional platform entries for linux arm64/rv64, android, iOS, web)
 ```
 
 **GDExtension limitations:** no in-editor documentation tooltips; `BBParam` property editor not available in the inspector.
@@ -98,7 +99,7 @@ public partial class EnemyAI : CharacterBody2D
 
     private void OnBtUpdated(int status)
     {
-        if (status == (int)BT.StatusEnum.Success)
+        if (status == (int)BT.Status.Success)
             _btPlayer.Restart();
     }
 }
@@ -383,7 +384,7 @@ public partial class IdleState : LimboState
 - [ ] Custom tasks annotated with `@tool` (GDScript) or `[Tool]` (C#) for editor display
 - [ ] Every `_tick` returns `SUCCESS`, `FAILURE`, or `RUNNING` — never `void`/`null`
 - [ ] Blackboard keys documented as exported `StringName` properties (suffix `_var`)
-- [ ] C# Blackboard reads cast the `Variant` explicitly (`(float)blackboard.GetVar(...)`)
+- [ ] C# Blackboard reads cast the `Variant` explicitly (`(float)Blackboard.GetVar(...)`)
 - [ ] C# uses module build (not GDExtension) for C# support
 - [ ] `BTPlayer.updated` signal used (not deprecated `behavior_tree_finished`)
 - [ ] HSM: all `LimboState` nodes wired with `add_transition` before `initialize()`

--- a/skills/limboai/SKILL.md
+++ b/skills/limboai/SKILL.md
@@ -1,0 +1,392 @@
+---
+name: limboai
+description: Use when using the LimboAI addon — behavior trees and hierarchical state machines (C++ GDExtension) with a visual editor, BTTask subclassing, and a blackboard
+---
+
+# LimboAI
+
+> **Related skills:** **ai-navigation** for movement the tasks drive, **state-machine** for core-engine FSM (when you don't need an addon), **godot-brainstorming** for choosing an AI approach.
+
+> **Addon:** LimboAI · version `v1.7.1` · Godot 4.6+ · MIT · source: https://github.com/limbonaut/limboai · written in C++ (GDExtension; engine-module build also available). GDExtension exposes GDScript; **C# requires the module build** (not GDExtension in v1.7.1).
+
+---
+
+## 1. When to use LimboAI
+
+| Approach | Best for |
+|---|---|
+| Core-engine FSM (`state-machine` skill) | Simple agents, < 5 states, no addon |
+| **Beehave** (GDScript addon) | Lightweight BT, GDScript-only projects |
+| **LimboAI** | BT **and** HSM together, visual editor, C++ performance, C# support (module build) |
+
+Choose LimboAI when you need a behavior tree with a polished visual debugger, want to combine it with a hierarchical state machine (`BTState` bridges them), or need C++ task execution speed. For a simpler GDScript-only behavior tree, Beehave is a lighter alternative. For plain state machines without a BT, use the built-in `state-machine` skill instead.
+
+---
+
+## 2. Install & setup
+
+### GDExtension (recommended — no custom engine)
+
+1. **Godot AssetLib** → search "LimboAI" → Download → Reload project.  
+   Or download from GitHub Releases and place `addons/limboai/` in `res://addons/limboai/`.
+2. Enable the plugin: **Project → Project Settings → Plugins** → tick LimboAI.
+3. The `.gdextension` manifest ships at `res://addons/limboai/bin/`:
+
+```ini
+[configuration]
+entry_symbol = "limboai_init"
+compatibility_minimum = "4.2"
+
+[libraries]
+windows.debug.x86_64   = "res://addons/limboai/bin/liblimboai.windows.editor.x86_64.dll"
+windows.release.x86_64 = "res://addons/limboai/bin/liblimboai.windows.template_release.x86_64.dll"
+linux.debug.x86_64     = "res://addons/limboai/bin/liblimboai.linux.editor.x86_64.so"
+linux.release.x86_64   = "res://addons/limboai/bin/liblimboai.linux.template_release.x86_64.so"
+macos.debug            = "res://addons/limboai/bin/liblimboai.macos.editor.framework"
+macos.release          = "res://addons/limboai/bin/liblimboai.macos.template_release.framework"
+```
+
+**GDExtension limitations:** no in-editor documentation tooltips; `BBParam` property editor not available in the inspector.
+
+### Module version (C# or full editor integration)
+
+Download pre-compiled editor + export templates from [GitHub Releases](https://github.com/limbonaut/limboai/releases). Requires the custom engine for export. The module build ships a NuGet package for C#:
+
+```ini
+# Add local NuGet source to your project:
+# dotnet nuget add source path/to/nupkgs --name LimboNugetSource
+```
+
+---
+
+## 3. Behavior trees
+
+A `BehaviorTree` resource holds the task tree. `BTPlayer` runs it each physics frame (or idle/manual). Add `BTPlayer` as a child of the agent node and assign a `BehaviorTree` resource.
+
+### GDScript
+
+```gdscript
+# EnemyAI.gd — assign behavior_tree in the Inspector or here
+extends CharacterBody2D
+
+@onready var bt_player: BTPlayer = $BTPlayer
+
+func _ready() -> void:
+    # BTPlayer starts executing automatically (active = true by default).
+    # Connect to updated(status) to react when the tree finishes.
+    bt_player.updated.connect(_on_bt_updated)
+
+func _on_bt_updated(status: int) -> void:
+    if status == BT.SUCCESS:
+        bt_player.restart()  # loop the tree
+```
+
+### C#
+
+```csharp
+// EnemyAI.cs
+using Godot;
+
+public partial class EnemyAI : CharacterBody2D
+{
+    [Export] private BTPlayer _btPlayer;
+
+    public override void _Ready()
+    {
+        _btPlayer.Updated += OnBtUpdated;
+    }
+
+    private void OnBtUpdated(int status)
+    {
+        if (status == (int)BT.StatusEnum.Success)
+            _btPlayer.Restart();
+    }
+}
+```
+
+`BTPlayer.UpdateMode` controls when the tree ticks: `IDLE` (every `_process`), `PHYSICS` (every `_physics_process`, default), or `MANUAL` (call `bt_player.update(delta)` yourself).
+
+---
+
+## 4. Custom tasks
+
+Subclass `BTAction` (multi-tick work) or `BTCondition` (immediate check). Annotate with `@tool` so `_generate_name()` and `_get_configuration_warnings()` work in the editor. Place scripts under `res://ai/tasks/`; subfolders become task categories.
+
+### GDScript
+
+```gdscript
+@tool
+extends BTAction
+## Moves the agent toward a blackboard position each tick.
+
+@export var target_pos_var: StringName = &"target_pos"
+@export var speed: float = 200.0
+
+func _generate_name() -> String:
+    return "MoveToward %s" % LimboUtility.decorate_var(target_pos_var)
+
+func _setup() -> void:
+    pass  # one-time init; agent and blackboard are available here
+
+func _enter() -> void:
+    pass  # called when task transitions from non-RUNNING → RUNNING
+
+func _tick(delta: float) -> Status:
+    var target: Vector2 = blackboard.get_var(target_pos_var, Vector2.ZERO)
+    if agent.global_position.distance_to(target) < 5.0:
+        return SUCCESS
+    agent.velocity = agent.global_position.direction_to(target) * speed
+    agent.move_and_slide()
+    return RUNNING
+
+func _exit() -> void:
+    pass  # cleanup after SUCCESS or FAILURE
+```
+
+```gdscript
+@tool
+extends BTCondition
+## Returns SUCCESS if the agent is within range of a target node.
+
+@export var target_var: StringName = &"target"
+@export var distance_max: float = 150.0
+
+var _max_sq: float
+
+func _setup() -> void:
+    _max_sq = distance_max * distance_max
+
+func _tick(_delta: float) -> Status:
+    var target: Node2D = blackboard.get_var(target_var, null)
+    if not is_instance_valid(target):
+        return FAILURE
+    var in_range := agent.global_position.distance_squared_to(
+        target.global_position) <= _max_sq
+    return SUCCESS if in_range else FAILURE
+```
+
+### C#
+
+```csharp
+// MoveTowardTask.cs — place in res://ai/tasks/
+using Godot;
+
+[Tool]
+public partial class MoveTowardTask : BTAction
+{
+    [Export] public StringName TargetPosVar { get; set; } = "target_pos";
+    [Export] public float Speed { get; set; } = 200f;
+
+    public override string _GenerateName() =>
+        $"MoveToward {LimboUtility.DecorateVar(TargetPosVar)}";
+
+    public override void _Setup() { }
+
+    public override void _Enter() { }
+
+    public override Status _Tick(double delta)
+    {
+        var target = (Vector2)Blackboard.GetVar(TargetPosVar, Vector2.Zero);
+        var body = (CharacterBody2D)Agent;
+        if (body.GlobalPosition.DistanceTo(target) < 5f)
+            return Status.Success;
+        body.Velocity = body.GlobalPosition.DirectionTo(target) * Speed;
+        body.MoveAndSlide();
+        return Status.Running;
+    }
+
+    public override void _Exit() { }
+}
+```
+
+```csharp
+// InRangeCondition.cs
+using Godot;
+
+[Tool]
+public partial class InRangeCondition : BTCondition
+{
+    [Export] public StringName TargetVar { get; set; } = "target";
+    [Export] public float DistanceMax { get; set; } = 150f;
+
+    private float _maxSq;
+
+    public override void _Setup() => _maxSq = DistanceMax * DistanceMax;
+
+    public override Status _Tick(double delta)
+    {
+        var target = Blackboard.GetVar(TargetVar, default(Variant)) as Node2D;
+        if (!GodotObject.IsInstanceValid(target))
+            return Status.Failure;
+        var agent2D = (Node2D)Agent;
+        bool inRange = agent2D.GlobalPosition.DistanceSquaredTo(
+            target.GlobalPosition) <= _maxSq;
+        return inRange ? Status.Success : Status.Failure;
+    }
+}
+```
+
+Task lifecycle: `_setup()` once before first tick → `_enter()` when status transitions from non-RUNNING → `_tick(delta)` every execution → `_exit()` after SUCCESS or FAILURE.
+
+---
+
+## 5. Blackboard
+
+The `Blackboard` is a `RefCounted` key/value store shared by all tasks in a tree. Use `StringName` keys (`&"key"`) and export them as task properties so the inspector shows a picker.
+
+### GDScript
+
+```gdscript
+@tool
+extends BTAction
+
+@export var speed_var: StringName = &"speed"
+@export var target_var: StringName = &"target"
+
+func _tick(delta: float) -> Status:
+    # Read with a default; use no type annotation for object vars
+    # to avoid errors if the stored instance was freed.
+    var speed: float = blackboard.get_var(speed_var, 100.0)
+    var obj = blackboard.get_var(target_var, null)
+    if not is_instance_valid(obj):
+        return FAILURE
+
+    # Write back
+    blackboard.set_var(speed_var, speed * 1.1)
+    return RUNNING
+```
+
+### C#
+
+```csharp
+// C# has no generic GetVar<T> — cast the returned Variant.
+using Godot;
+
+[Tool]
+public partial class SampleTask : BTAction
+{
+    [Export] public StringName SpeedVar { get; set; } = "speed";
+    [Export] public StringName TargetVar { get; set; } = "target";
+
+    public override Status _Tick(double delta)
+    {
+        float speed = (float)Blackboard.GetVar(SpeedVar, 100f);
+        var obj = Blackboard.GetVar(TargetVar, default(Variant)).As<GodotObject>();
+        if (!GodotObject.IsInstanceValid(obj))
+            return Status.Failure;
+
+        Blackboard.SetVar(SpeedVar, speed * 1.1f);
+        return Status.Running;
+    }
+}
+```
+
+Useful `Blackboard` methods: `has_var(name)`, `erase_var(name)`, `list_vars()`, `get_vars_as_dict()`, `bind_var_to_property(name, obj, prop)`, `link_var(name, target_bb, target_name)`, `print_state()` (debug).
+
+`BlackboardPlan` defines the variable schema (types, defaults, hints) and is edited in the Inspector on `BTPlayer` or `LimboHSM`. Call `blackboard_plan.create_blackboard(scene_root)` to create a scoped `Blackboard` at runtime.
+
+---
+
+## 6. Hierarchical state machine (LimboHSM)
+
+`LimboHSM` is a `LimboState` node that manages child `LimboState` nodes. Transitions fire when a state calls `dispatch(event)`. See [references/hsm.md](references/hsm.md) for advanced patterns (any-state transitions, `BTState`, nested HSMs, guards).
+
+### GDScript — scene-tree setup
+
+```gdscript
+# Character.gd — scene tree: Character → LimboHSM → IdleState, MoveState
+extends CharacterBody2D
+
+@onready var hsm: LimboHSM = $LimboHSM
+@onready var idle: LimboState = $LimboHSM/IdleState
+@onready var move: LimboState = $LimboHSM/MoveState
+
+func _ready() -> void:
+    hsm.add_transition(idle, move, idle.EVENT_FINISHED)
+    hsm.add_transition(move, idle, move.EVENT_FINISHED)
+    hsm.initialize(self)
+    hsm.set_active(true)
+```
+
+### C# — scene-tree setup
+
+```csharp
+// Character.cs
+using Godot;
+
+public partial class Character : CharacterBody2D
+{
+    [Export] private LimboHSM _hsm;
+    [Export] private LimboState _idle;
+    [Export] private LimboState _move;
+
+    public override void _Ready()
+    {
+        _hsm.AddTransition(_idle, _move, _idle.EventFinished);
+        _hsm.AddTransition(_move, _idle, _move.EventFinished);
+        _hsm.Initialize(this);
+        _hsm.SetActive(true);
+    }
+}
+```
+
+### GDScript — state script
+
+```gdscript
+# IdleState.gd
+extends LimboState
+
+func _setup() -> void:
+    pass  # agent and blackboard available; runs once during hsm.initialize()
+
+func _enter() -> void:
+    agent.get_node("AnimationPlayer").play("idle")
+
+func _exit() -> void:
+    pass
+
+func _update(delta: float) -> void:
+    if Input.get_vector(&"ui_left", &"ui_right", &"ui_up", &"ui_down").length() > 0.1:
+        dispatch(EVENT_FINISHED)
+```
+
+### C# — state script
+
+```csharp
+// IdleState.cs
+using Godot;
+
+public partial class IdleState : LimboState
+{
+    public override void _Setup() { }
+
+    public override void _Enter()
+    {
+        Agent.GetNode<AnimationPlayer>("AnimationPlayer").Play("idle");
+    }
+
+    public override void _Exit() { }
+
+    public override void _Update(double delta)
+    {
+        if (Input.GetVector("ui_left", "ui_right", "ui_up", "ui_down").Length() > 0.1f)
+            Dispatch(EventFinished);
+    }
+}
+```
+
+---
+
+## Implementation checklist
+
+- [ ] `BTPlayer` added as a child of the agent; `behavior_tree` resource assigned
+- [ ] Custom tasks annotated with `@tool` (GDScript) or `[Tool]` (C#) for editor display
+- [ ] Every `_tick` returns `SUCCESS`, `FAILURE`, or `RUNNING` — never `void`/`null`
+- [ ] Blackboard keys documented as exported `StringName` properties (suffix `_var`)
+- [ ] C# Blackboard reads cast the `Variant` explicitly (`(float)blackboard.GetVar(...)`)
+- [ ] C# uses module build (not GDExtension) for C# support
+- [ ] `BTPlayer.updated` signal used (not deprecated `behavior_tree_finished`)
+- [ ] HSM: all `LimboState` nodes wired with `add_transition` before `initialize()`
+- [ ] HSM: `set_active(true)` called after `initialize()`
+- [ ] HSM transitions are exhaustive — every reachable state has an exit path
+- [ ] `BBParam` inspector binding: use module build; GDExtension lacks the param editor UI

--- a/skills/limboai/SKILL.md
+++ b/skills/limboai/SKILL.md
@@ -19,7 +19,7 @@ description: Use when using the LimboAI addon — behavior trees and hierarchica
 | **Beehave** (GDScript addon) | Lightweight BT, GDScript-only projects |
 | **LimboAI** | BT **and** HSM together, visual editor, C++ performance, C# support (module build) |
 
-Choose LimboAI when you need a behavior tree with a polished visual debugger, want to combine it with a hierarchical state machine (`BTState` bridges them), or need C++ task execution speed. For a simpler GDScript-only behavior tree, Beehave is a lighter alternative. For plain state machines without a BT, use the built-in `state-machine` skill instead.
+Choose LimboAI when you need a behavior tree with a polished visual debugger, want to combine it with a hierarchical state machine (`BTState` bridges them), or need C++ task execution speed. Note: LimboAI requires **Godot 4.6+** and is not usable on 4.3–4.5. For a simpler GDScript-only behavior tree, Beehave is a lighter alternative. For plain state machines without a BT, use the built-in `state-machine` skill instead.
 
 ---
 
@@ -216,7 +216,7 @@ public partial class InRangeCondition : BTCondition
 
     public override Status _Tick(double delta)
     {
-        var target = Blackboard.GetVar(TargetVar, default(Variant)) as Node2D;
+        var target = Blackboard.GetVar(TargetVar, default(Variant)).As<Node2D>();
         if (!GodotObject.IsInstanceValid(target))
             return Status.Failure;
         var agent2D = (Node2D)Agent;

--- a/skills/limboai/references/hsm.md
+++ b/skills/limboai/references/hsm.md
@@ -1,0 +1,185 @@
+# LimboAI — Advanced HSM Patterns
+
+> Deep-dive reference for `LimboHSM` + `LimboState` + `BTState`. Load when you need any-state transitions, guard callables, nested HSMs, or HSM + BT bridging via `BTState`.
+
+---
+
+## Any-state transitions
+
+Use `hsm.ANYSTATE` as `from_state` to define a transition that fires from any active state:
+
+### GDScript
+
+```gdscript
+# From any state, dispatch "stunned" → go to StunnedState
+hsm.add_transition(hsm.ANYSTATE, stunned_state, &"stunned")
+hsm.add_transition(hsm.ANYSTATE, dead_state, &"died")
+```
+
+### C#
+
+```csharp
+_hsm.AddTransition(_hsm.Anystate, _stunnedState, "stunned");
+_hsm.AddTransition(_hsm.Anystate, _deadState, "died");
+```
+
+---
+
+## Guard callables
+
+A guard prevents a transition from firing unless the callable returns `true`:
+
+### GDScript
+
+```gdscript
+func _has_enough_health() -> bool:
+    return agent.health > 0.0
+
+func _ready() -> void:
+    hsm.add_transition(idle_state, move_state, &"movement_started",
+        _has_enough_health)
+```
+
+### C#
+
+```csharp
+private bool HasEnoughHealth() => _agent.Health > 0f;
+
+public override void _Ready()
+{
+    _hsm.AddTransition(_idle, _move, "movement_started",
+        Callable.From(HasEnoughHealth));
+}
+```
+
+---
+
+## Fluent (single-file) setup
+
+Create states programmatically without scene-tree nodes — useful for procedural or data-driven characters:
+
+### GDScript
+
+```gdscript
+func _init_hsm() -> void:
+    var hsm := LimboHSM.new()
+    add_child(hsm)
+
+    var idle := LimboState.new().named("Idle") \
+        .call_on_enter(func(): $AnimationPlayer.play("idle")) \
+        .call_on_update(_idle_update)
+    var move := LimboState.new().named("Move") \
+        .call_on_enter(func(): $AnimationPlayer.play("walk")) \
+        .call_on_update(_move_update)
+
+    hsm.add_child(idle)
+    hsm.add_child(move)
+    hsm.add_transition(idle, move, &"movement_started")
+    hsm.add_transition(move, idle, &"movement_ended")
+    hsm.initialize(self)
+    hsm.set_active(true)
+```
+
+### C#
+
+```csharp
+// Fluent chaining (.Named()/.CallOnEnter()) is GDScript-only via LimboState builder methods.
+// In C# assign properties and connect signals instead.
+private void InitHsm()
+{
+    var hsm = new LimboHSM();
+    AddChild(hsm);
+
+    var idle = new LimboState { Name = "Idle" };
+    idle.Connect(LimboState.SignalName.Entered,
+        Callable.From(() => GetNode<AnimationPlayer>("AnimationPlayer").Play("idle")));
+    idle.Connect(LimboState.SignalName.Updated,
+        Callable.From((double d) => IdleUpdate(d)));
+
+    var move = new LimboState { Name = "Move" };
+    move.Connect(LimboState.SignalName.Entered,
+        Callable.From(() => GetNode<AnimationPlayer>("AnimationPlayer").Play("walk")));
+    move.Connect(LimboState.SignalName.Updated,
+        Callable.From((double d) => MoveUpdate(d)));
+
+    hsm.AddChild(idle);
+    hsm.AddChild(move);
+    hsm.AddTransition(idle, move, "movement_started");
+    hsm.AddTransition(move, idle, "movement_ended");
+    hsm.Initialize(this);
+    hsm.SetActive(true);
+}
+```
+
+---
+
+## BTState — bridging HSM and behavior trees
+
+`BTState` is a `LimboState` that runs a `BehaviorTree` resource. When the BT returns `SUCCESS` it dispatches `success_event`; on `FAILURE` it dispatches `failure_event`. Use it to embed a BT inside an HSM state slot:
+
+### GDScript
+
+```gdscript
+func _ready() -> void:
+    var hsm := LimboHSM.new()
+    add_child(hsm)
+
+    var patrol := BTState.new()
+    patrol.behavior_tree = preload("res://ai/trees/patrol.tres")
+    patrol.set_scene_root_hint(self)  # call before initialize()
+    # patrol.success_event = &"patrol_done"  # default is &"success"
+
+    hsm.add_child(patrol)
+    hsm.initial_state = patrol
+    hsm.initialize(self)
+    hsm.set_active(true)
+```
+
+### C#
+
+```csharp
+public override void _Ready()
+{
+    var hsm = new LimboHSM();
+    AddChild(hsm);
+
+    var patrol = new BTState();
+    patrol.BehaviorTree = GD.Load<BehaviorTree>("res://ai/trees/patrol.tres");
+    patrol.SetSceneRootHint(this);  // call before Initialize()
+
+    hsm.AddChild(patrol);
+    hsm.InitialState = patrol;
+    hsm.Initialize(this);
+    hsm.SetActive(true);
+}
+```
+
+---
+
+## Dispatching events
+
+Any state or external code can dispatch events. Events propagate from the leaf state up to the root:
+
+### GDScript
+
+```gdscript
+# From inside a LimboState subclass:
+dispatch(EVENT_FINISHED)           # use per-state shorthand
+dispatch(&"stunned", damage_info)  # named event with cargo
+
+# From outside (e.g. the agent script):
+hsm.dispatch(&"player_spotted")
+```
+
+### C#
+
+```csharp
+// From inside a LimboState subclass:
+Dispatch(EventFinished);
+Dispatch("stunned", damageInfo);
+
+// From outside:
+_hsm.Dispatch("player_spotted");
+```
+
+`dispatch()` returns `true` if an event was consumed by a transition. Unhandled events are silently ignored.

--- a/skills/resource-pattern/SKILL.md
+++ b/skills/resource-pattern/SKILL.md
@@ -7,7 +7,7 @@ description: Use when creating data containers in Godot — custom Resources for
 
 Resources are Godot's built-in data containers. Use them for configuration, item definitions, character stats, and any data that lives outside the scene tree. All examples target Godot 4.3+ with no deprecated APIs.
 
-> **Related skills:** **inventory-system** for Resource-based item definitions, **save-load** for Resource serialization, **component-system** for data-driven component configuration.
+> **Related skills:** **inventory-system** for Resource-based item definitions, **save-load** for Resource serialization, **component-system** for data-driven component configuration, **ability-system** for Resource-based ability definitions built on this pattern.
 
 ---
 

--- a/skills/state-machine/SKILL.md
+++ b/skills/state-machine/SKILL.md
@@ -7,7 +7,9 @@ description: Use when implementing state machines in Godot — enum-based, node-
 
 Choose the right FSM pattern for your complexity level. All examples target Godot 4.3+ with no deprecated APIs.
 
-> **Related skills:** **player-controller** for movement state integration, **ai-navigation** for AI state patterns, **resource-pattern** for resource-based state configuration, **animation-system** for AnimationTree states driven by FSM, **dialogue-system** for dialogue flow as a state machine.
+> **Related skills:** **player-controller** for movement state integration, **ai-navigation** for AI state patterns, **resource-pattern** for resource-based state configuration, **animation-system** for AnimationTree states driven by FSM, **dialogue-system** for dialogue flow as a state machine, **ability-system** for caster state gating (casting/stunned), **limboai** for the LimboAI addon's HSM (`BTState`) if you need a behavior tree alongside your FSM, **beehave** for a GDScript-only BT alternative.
+
+> **When to reach for an addon:** This skill covers the built-in FSM patterns (enum, node-based, resource-based). If your agent needs a full behavior tree, see **limboai** (C++ + HSM, Godot 4.6+) or **beehave** (pure GDScript, Godot 4.1+) instead.
 
 ---
 

--- a/skills/using-godot-prompter/SKILL.md
+++ b/skills/using-godot-prompter/SKILL.md
@@ -19,6 +19,10 @@ GodotPrompter provides Godot 4.x domain-specific skills for AI coding agents. Sk
 
 **In Cursor:** Skills are loaded via custom instructions / rules system.
 
+**In Codex:** Skills load natively via the AGENTS.md re-export. Follow skill instructions directly; see `references/codex-tools.md` for tool mapping.
+
+**In OpenCode:** Skills are discovered from the installed plugin. Use the `/skills` command to browse or invoke skills directly. See `.opencode/INSTALL.md` for setup.
+
 **In Antigravity (2.0, IDE, CLI):** Skills activate automatically when your prompt matches a skill's `description` frontmatter — no tool call needed. Install skills into `.agents/skills/` (workspace) or `~/.gemini/config/skills/` (global). See `references/antigravity-tools.md` for tool mapping and full install instructions.
 
 ### Installing GodotPrompter for Antigravity

--- a/skills/using-godot-prompter/SKILL.md
+++ b/skills/using-godot-prompter/SKILL.md
@@ -19,6 +19,37 @@ GodotPrompter provides Godot 4.x domain-specific skills for AI coding agents. Sk
 
 **In Cursor:** Skills are loaded via custom instructions / rules system.
 
+**In Antigravity (2.0, IDE, CLI):** Skills activate automatically when your prompt matches a skill's `description` frontmatter — no tool call needed. Install skills into `.agents/skills/` (workspace) or `~/.gemini/config/skills/` (global). See `references/antigravity-tools.md` for tool mapping and full install instructions.
+
+### Installing GodotPrompter for Antigravity
+
+**Workspace (project-scoped) — recommended for active development:**
+
+```bash
+# Linux / macOS — from your Godot project root:
+mkdir -p .agents
+ln -s /path/to/GodotPrompter/skills .agents/skills
+
+# Windows (PowerShell, Developer Mode or run as admin):
+New-Item -ItemType Junction -Path .agents\skills -Target D:\Godot\GodotPrompter\skills
+```
+
+> **Legacy path note:** `.agent/skills/` (singular) was the early CLI convention; `.agents/skills/` (plural) is the current standard for all Antigravity products.
+
+**Global (cross-project):**
+
+```bash
+# Official path (Google Codelabs): ~/.gemini/config/skills/
+# Symlink individual skill folders so each is a direct child (recommended):
+ln -s /path/to/GodotPrompter/skills/* ~/.gemini/config/skills/
+```
+
+> `~/.gemini/skills/` is a community-verified alias but not the path the official Codelabs docs name. Prefer `~/.gemini/config/skills/` for new installs.
+
+> **Nesting caveat:** Prefer `ln -s skills/*` over cloning the repo directly into the skills dir, so each skill is an immediate child (`<skills-dir>/<skill-name>/SKILL.md`). Confirm nested discovery works before relying on the clone approach.
+
+See `references/antigravity-tools.md` for the full tool mapping and SKILL.md frontmatter details.
+
 ## Coexistence with Other Plugins (e.g., Superpowers)
 
 When another plugin (like Superpowers) is handling workflow (brainstorming, planning, execution), GodotPrompter skills STILL APPLY during implementation. They are not replaced — they are domain-specific guidance that workflow plugins cannot provide.

--- a/skills/using-godot-prompter/SKILL.md
+++ b/skills/using-godot-prompter/SKILL.md
@@ -97,6 +97,7 @@ Skills use Claude Code tool names as the canonical reference. Non-Claude platfor
 - [`references/codex-tools.md`](references/codex-tools.md) — Codex
 - [`references/cursor-tools.md`](references/cursor-tools.md) — Cursor
 - [`references/gemini-tools.md`](references/gemini-tools.md) — Gemini CLI (Gemini also auto-loads this via `GEMINI.md`)
+- [`references/antigravity-tools.md`](references/antigravity-tools.md) — Antigravity (2.0 desktop, IDE, CLI)
 
 ## Available Skill Categories
 

--- a/skills/using-godot-prompter/SKILL.md
+++ b/skills/using-godot-prompter/SKILL.md
@@ -35,6 +35,7 @@ mkdir -p .agents
 ln -s /path/to/GodotPrompter/skills .agents/skills
 
 # Windows (PowerShell, Developer Mode or run as admin):
+New-Item -ItemType Directory -Force .agents | Out-Null   # junction won't create the parent
 New-Item -ItemType Junction -Path .agents\skills -Target D:\Godot\GodotPrompter\skills
 ```
 
@@ -45,6 +46,7 @@ New-Item -ItemType Junction -Path .agents\skills -Target D:\Godot\GodotPrompter\
 ```bash
 # Official path (Google Codelabs): ~/.gemini/config/skills/
 # Symlink individual skill folders so each is a direct child (recommended):
+mkdir -p ~/.gemini/config/skills/
 ln -s /path/to/GodotPrompter/skills/* ~/.gemini/config/skills/
 ```
 

--- a/skills/using-godot-prompter/references/antigravity-tools.md
+++ b/skills/using-godot-prompter/references/antigravity-tools.md
@@ -1,0 +1,99 @@
+# Antigravity Tool Mapping
+
+Skills use Claude Code tool names. When you encounter these in a skill, use your platform equivalent:
+
+| Skill references | Antigravity equivalent |
+|-----------------|------------------------|
+| `Read` (file reading) | `Read()` |
+| `Write` (file creation) | `Create()` |
+| `Edit` (file editing) | `Edit()` / `Replace()` (unconfirmed — verify in-app) |
+| `Bash` (run commands) | `Bash()` |
+| `Grep` (search file content) | No dedicated tool — use `Bash("grep ...")` (unconfirmed — verify in-app) |
+| `Glob` (search files by name) | `ListDir()` |
+| `WebSearch` | `WebSearch()` |
+| `WebFetch` | `ReadURL()` |
+| `Task` tool (dispatch subagent) | `Subagent()` / delegate via natural language (unconfirmed — verify in-app) |
+| `Skill` tool (invoke a skill) | No tool call — skills activate via `description` frontmatter matching |
+
+## Skill Discovery
+
+Antigravity indexes skill frontmatter at startup, then loads the matching skill body on demand when the
+user's prompt semantically matches a skill's `description` field.
+
+### Workspace (project-scoped) skills
+
+Place (or symlink) GodotPrompter skills into `.agents/skills/` inside your Godot project:
+
+```
+.agents/
+  skills/
+    player-controller/
+      SKILL.md
+    state-machine/
+      SKILL.md
+    ...
+```
+
+Recommended setup (symlink the whole `skills/` directory):
+
+```bash
+# Linux / macOS — from your Godot project root:
+mkdir -p .agents
+ln -s /path/to/GodotPrompter/skills .agents/skills
+
+# Windows (PowerShell, Developer Mode or run as admin):
+New-Item -ItemType Junction -Path .agents\skills -Target D:\Godot\GodotPrompter\skills
+```
+
+> **Legacy path:** `.agent/skills/` (singular) was the early Antigravity CLI convention and may still
+> work for backward compatibility, but `.agents/skills/` (plural) is the current standard for all
+> Antigravity products (2.0 desktop, IDE, CLI). Use the plural form for new setups.
+
+### Global (cross-project) skills
+
+Official path (Google Codelabs): `~/.gemini/config/skills/`
+
+```bash
+# Symlink individual skill folders (recommended — each skill is a direct child):
+ln -s /path/to/GodotPrompter/skills/* ~/.gemini/config/skills/
+# Result: ~/.gemini/config/skills/player-controller/SKILL.md  etc.
+
+# Or clone the repo (mind the nesting caveat below):
+git clone https://github.com/jame581/GodotPrompter ~/.gemini/config/skills/godot-prompter
+```
+
+> **Community alias:** `~/.gemini/skills/` is reported to work as an alias in practice (verified by
+> community sources) but is not the path the official Codelabs documentation names. Prefer
+> `~/.gemini/config/skills/` for new installs.
+
+> **Nesting caveat:** If you use the `git clone` approach, skills land at
+> `~/.gemini/config/skills/godot-prompter/<skill-name>/SKILL.md`. Confirm that Antigravity discovers
+> skills nested one extra level before relying on this path; if not, use `ln -s skills/*` instead so
+> each skill is a direct child of the skills directory.
+
+## SKILL.md Frontmatter
+
+Antigravity reads two required fields from each `SKILL.md`:
+
+| Field | Role |
+|-------|------|
+| `name` | Skill identifier (lowercase, hyphenated). Defaults to the directory name if omitted. |
+| `description` | Semantic trigger — Antigravity matches this against the user's prompt to select the skill. Most important field. |
+
+GodotPrompter's existing `name:` and `description:` frontmatter is already compatible. No changes to
+skill files are required.
+
+An optional `tools:` field can restrict which MCP servers are available when the skill runs (e.g.,
+`tools: mcp_google-developer-knowledge_*`). GodotPrompter skills do not use this field by default.
+
+## references/ Subdirectory
+
+Antigravity does **not** auto-load `references/` files. The SKILL.md body must explicitly instruct the
+agent to read a specific file (e.g., "read `references/X.md` for details on Y"). This is the same
+behaviour as Claude Code — GodotPrompter's Pattern X (load-on-demand references) works identically.
+
+## Project Instructions
+
+Antigravity does not read `AGENTS.md` as project-level instructions (that file is for Codex). For
+project-wide Antigravity instructions, create `.gemini/GEMINI.md` at your project root. A user-level
+config file also lives at `~/.gemini/GEMINI.md`.

--- a/skills/using-godot-prompter/references/antigravity-tools.md
+++ b/skills/using-godot-prompter/references/antigravity-tools.md
@@ -49,6 +49,8 @@ New-Item -ItemType Junction -Path .agents\skills -Target D:\Godot\GodotPrompter\
 > work for backward compatibility, but `.agents/skills/` (plural) is the current standard for all
 > Antigravity products (2.0 desktop, IDE, CLI). Use the plural form for new setups.
 
+> **Note:** `.antigravity/skills/` appears in some community write-ups but is not a recognized Antigravity skills path — do not use it.
+
 ### Global (cross-project) skills
 
 Official path (Google Codelabs): `~/.gemini/config/skills/`

--- a/skills/using-godot-prompter/references/antigravity-tools.md
+++ b/skills/using-godot-prompter/references/antigravity-tools.md
@@ -42,6 +42,7 @@ mkdir -p .agents
 ln -s /path/to/GodotPrompter/skills .agents/skills
 
 # Windows (PowerShell, Developer Mode or run as admin):
+New-Item -ItemType Directory -Force .agents | Out-Null   # junction won't create the parent
 New-Item -ItemType Junction -Path .agents\skills -Target D:\Godot\GodotPrompter\skills
 ```
 
@@ -57,6 +58,7 @@ Official path (Google Codelabs): `~/.gemini/config/skills/`
 
 ```bash
 # Symlink individual skill folders (recommended — each skill is a direct child):
+mkdir -p ~/.gemini/config/skills/
 ln -s /path/to/GodotPrompter/skills/* ~/.gemini/config/skills/
 # Result: ~/.gemini/config/skills/player-controller/SKILL.md  etc.
 


### PR DESCRIPTION
## Summary

v1.10.0 **"Ecosystem & Abilities"** — three independent workstreams shipped together. Grows the catalog **48 → 51 skills**, opens the repo to the community-addon ecosystem for the first time, and adds Antigravity as a supported platform.

Spec: `docs/superpowers/specs/2026-06-17-v1.10.0-design.md`
Plan: `docs/superpowers/plans/2026-06-17-v1.10.0-implementation.md`

## What's included

**3 new skills**
- **`ability-system`** (core gameplay) — Resource-based abilities (cost/cooldown/cast), buffs/debuffs as timed effects, a stat-modifier pipeline (ADD → MULTIPLY → OVERRIDE → clamp; stacking/refresh by source), a gameplay-tag/condition system (gating + immunities), and HUD binding. Pattern X (SKILL.md + 3 references). Full GDScript + C# parity.
- **`limboai`** — new **Third-Party Addons** category. LimboAI **v1.7.1** (C++ GDExtension; C# via the module build): behavior trees + HSM, `BTTask` lifecycle, blackboard, visual editor. SKILL.md + `references/hsm.md`. Full C# parity.
- **`beehave`** — Third-Party Addons. Beehave **v2.9.2** (pure GDScript): composites/decorators/leaves, the `tick(actor, blackboard)` contract, blackboard, visual debugger. SKILL.md + `references/custom-nodes.md`. **GDScript-only by design** (validator-allowlisted).

**Platform + ecosystem**
- New **"Third-Party Addons"** README category (addon skills pin version + install source).
- **Antigravity** added as a supported platform — `references/antigravity-tools.md` mapping + bootstrap/README/CLAUDE.md wiring. **Format-verified, runtime-pending** (no live Antigravity install on the build machine; honestly labeled, not overclaimed).

**Wiring & release prep**
- Reciprocal cross-refs (ai-navigation, state-machine, component-system, resource-pattern, event-bus, hud-system); light agent edits (godot-game-architect, godot-game-dev). No new agents.
- Version bumped to `1.10.0` across all 5 manifests; CHANGELOG; regenerated `docs/token-budget.md` (real tokenizer counts); counts → 51 everywhere.

## Validation

- `node scripts/validate-skills.mjs` → **0 errors, 13 warnings** — all `csharp-parity-accepted` (10 pre-existing + 3 from `beehave` being GDScript-only). Zero parity-missing / cross-ref-broken / orphan / token-budget-exceeded.
- Every `SKILL.md` ≤ 16 KB.
- Addon API verified verbatim against pinned source clones (LimboAI v1.7.1, Beehave v2.9.2).

## Review process

Built via subagent-driven development: a fresh implementer + independent reviewer per task, plus **two whole-branch review passes**. The reviews caught and we fixed several real defects, including four compile/runtime bugs (non-compiling `[Export]`, `Variant as Node2D`, a `Resource`-vs-`Node` mismatch, a fabricated `BT.StatusEnum`) and stale "48-skills" strings in the plugin manifest descriptions.

## After merge (release)

Tagging `v1.10.0` triggers `.github/workflows/release.yml`: validates, publishes the GitHub release, and opens marketplace bump PRs (skillsmith + godot-prompter-marketplace) via `MARKETPLACE_TOKEN`. Let the workflow handle the sibling marketplaces — do not hand-commit those clones.

## Follow-up (not in this PR)

`bump-version.mjs` updates `version` fields but not the "N domain-specific skills" count in manifest descriptions (the cause of the stale-48 strings, now fixed by hand). Worth teaching the script to update it, or adding a release-checklist reminder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)