### PR TITLE
fix(bump-version): sync skill count into manifest descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ model: inherit
 Current version: check `package.json` and `.claude-plugin/plugin.json` (must match).
 
 When releasing (full command sequence in `CONTRIBUTING.md`):
-1. `node scripts/bump-version.mjs <version>` — bumps `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, plus sibling marketplaces if present
+1. `node scripts/bump-version.mjs <version>` — bumps `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, plus sibling marketplaces if present; also syncs the live skill count into the "N domain-specific skills" text of each manifest description
 2. Update `CHANGELOG.md` with the new section
 3. Commit, tag (`v<version>`), push with tags — `.github/workflows/release.yml` then validates, creates the GitHub release, and opens marketplace PRs (when `MARKETPLACE_TOKEN` is configured)
 4. If the workflow's marketplace step is skipped, manually bump `skillsmith/.claude-plugin/marketplace.json` (primary) and the legacy `godot-prompter-marketplace/.claude-plugin/marketplace.json`

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Bumps version across in-repo files and (if present) sibling marketplace repos.
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -16,13 +16,25 @@ if (!newVersion || !/^\d+\.\d+\.\d+$/.test(newVersion)) {
 // instead of relying on array position — sibling marketplaces may add other plugins.
 const PLUGIN_NAME = 'godot-prompter';
 
+const SKILLS_DIR = resolve(ROOT, 'skills');
+
+// Count skill folders (subdirectories of skills/ that contain a SKILL.md) so the manifest
+// description strings ("N domain-specific skills") stay in sync with reality. This mirrors how
+// validate-skills.mjs enumerates skills. Without this, descriptions drift (e.g. stuck at "48").
+function countSkills() {
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter(d => d.isDirectory() && existsSync(resolve(SKILLS_DIR, d.name, 'SKILL.md')))
+    .length;
+}
+
+// `descKey` (optional) points at a description string carrying a skill count to keep current.
 const inRepoTargets = [
   { path: resolve(ROOT, 'package.json'), key: 'version' },
-  { path: resolve(ROOT, '.claude-plugin/plugin.json'), key: 'version' },
-  { path: resolve(ROOT, '.claude-plugin/marketplace.json'), key: `plugins[name=${PLUGIN_NAME}].version` },
+  { path: resolve(ROOT, '.claude-plugin/plugin.json'), key: 'version', descKey: 'description' },
+  { path: resolve(ROOT, '.claude-plugin/marketplace.json'), key: `plugins[name=${PLUGIN_NAME}].version`, descKey: `plugins[name=${PLUGIN_NAME}].description` },
   // Platform-specific manifests — easily missed before v1.7.1 because they live outside .claude-plugin/.
-  { path: resolve(ROOT, '.cursor-plugin/plugin.json'), key: 'version' },
-  { path: resolve(ROOT, 'gemini-extension.json'), key: 'version' },
+  { path: resolve(ROOT, '.cursor-plugin/plugin.json'), key: 'version', descKey: 'description' },
+  { path: resolve(ROOT, 'gemini-extension.json'), key: 'version', descKey: 'description' },
 ];
 
 // Sibling marketplaces. Tries each candidate path in order; first existing one wins per label.
@@ -43,7 +55,21 @@ const siblingTargets = [
     ],
     key: `plugins[name=${PLUGIN_NAME}].version`,
   },
-];
+].map(t => ({ ...t, descKey: `plugins[name=${PLUGIN_NAME}].description` }));
+
+const SKILL_COUNT = countSkills();
+
+// Replace the leading number in "<n> [domain-specific ]skill(s)" with the current skill count.
+// Returns the new count if the description changed, else null.
+function updateDescriptionCount(json, descKey) {
+  if (!descKey) return null;
+  const desc = getByPath(json, descKey);
+  if (typeof desc !== 'string') return null;
+  const updated = desc.replace(/\b\d+(\s+(?:domain-specific\s+)?skills?\b)/i, `${SKILL_COUNT}$1`);
+  if (updated === desc) return null;
+  setByPath(json, descKey, updated);
+  return SKILL_COUNT;
+}
 
 // Path syntax: "a.b.c" walks objects; "a[name=X].b" finds the array element where .name === X.
 // The matchKey accepts hyphens and underscores so keys like "display-name" or "plugin_id" work.
@@ -82,8 +108,9 @@ function bump(target) {
   const current = getByPath(json, target.key);
   if (!current) throw new Error(`No version at ${target.key} in ${target.path}`);
   setByPath(json, target.key, newVersion);
+  const descUpdated = updateDescriptionCount(json, target.descKey);
   writeFileSync(target.path, JSON.stringify(json, null, 2) + '\n');
-  return current;
+  return { current, descUpdated };
 }
 
 // Verify in-repo versions are in sync before bumping
@@ -96,18 +123,18 @@ if (distinct.length > 1) {
   process.exit(1);
 }
 
-console.log(`Bumping ${distinct[0]} -> ${newVersion}`);
+console.log(`Bumping ${distinct[0]} -> ${newVersion} (skill count: ${SKILL_COUNT})`);
 
 for (const t of inRepoTargets) {
-  const prev = bump(t);
-  console.log(`  ${t.path}: ${prev} -> ${newVersion}`);
+  const { current: prev, descUpdated } = bump(t);
+  console.log(`  ${t.path}: ${prev} -> ${newVersion}${descUpdated ? ` (description synced to ${descUpdated} skills)` : ''}`);
 }
 
 for (const t of siblingTargets) {
   const found = t.paths.find(p => existsSync(p));
   if (found) {
-    const prev = bump({ path: found, key: t.key });
-    console.log(`  [${t.label}] ${found}: ${prev} -> ${newVersion}`);
+    const { current: prev, descUpdated } = bump({ path: found, key: t.key, descKey: t.descKey });
+    console.log(`  [${t.label}] ${found}: ${prev} -> ${newVersion}${descUpdated ? ` (description synced to ${descUpdated} skills)` : ''}`);
   } else {
     console.log(`  [${t.label}] not found at any of: ${t.paths.join(', ')} — bump manually after the release tag`);
   }


### PR DESCRIPTION
## Problem

`bump-version.mjs` updated `version` fields but never touched the **"N domain-specific skills"** text in the plugin/marketplace/cursor/gemini manifest descriptions. That count drifted — it stayed at **48** through the entire v1.10.0 cycle and was only caught by a Copilot review on PR #7 (then hand-fixed to 51).

## Fix

- Adds `countSkills()` — counts subdirectories of `skills/` containing a `SKILL.md` (same enumeration as `validate-skills.mjs`).
- During the bump, rewrites the leading number in any manifest description matching `<n> [domain-specific ]skill(s)` to the live count, for in-repo manifests **and** sibling marketplace entries.
- Descriptions without a skill count (e.g. `package.json`) are left untouched.
- Logs `(description synced to N skills)` per file.

## Verification

- Unit-tested the count + regex (count = 51; the count variants update, count-less descriptions stay unchanged).
- **End-to-end test in an isolated sandbox** (real script, fake repo with 3 skill dirs, no sibling clones nearby): all 5 manifests bumped, count-bearing descriptions synced to "3 ... skills", `package.json` description untouched, the marketplace array-selector path handled, absent siblings safely skipped.
- `node --check` passes; `validate-skills.mjs` still 0 errors / 13 warnings.

Updates the `CLAUDE.md` release step to note the new behavior. No more manual description-count edits on skill-count changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)