### PR TITLE
docs(codex): add Windows clone command to INSTALL.md

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -13,6 +13,11 @@ Enable GodotPrompter skills in Codex via native skill discovery. Just clone and 
    git clone https://github.com/jame581/GodotPrompter.git ~/.codex/godot-prompter
    ```
 
+   **Windows (PowerShell):**
+   ```powershell
+   git clone https://github.com/jame581/GodotPrompter.git "$env:USERPROFILE\.codex\godot-prompter"
+   ```
+
 2. **Create the skills symlink:**
    ```bash
    mkdir -p ~/.agents/skills


### PR DESCRIPTION
## Summary

Fixes #10. In `.codex/INSTALL.md`, steps 2 and 3 already had **Windows (PowerShell)** variants, but step 1 (the `git clone`) only had the bash version using `~`. On Windows that clones the repo into a folder literally named `~`.

Added the PowerShell variant, matching the existing Windows blocks:

```powershell
git clone https://github.com/jame581/GodotPrompter.git "$env:USERPROFILE\.codex\godot-prompter"
```

The README's Codex section already points to `.codex/INSTALL.md` for Windows instructions, so no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)